### PR TITLE
Close the WebSocket connection when ws-mock changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **WebSocket auto-reconnect on mock update** — updating or deleting a WebSocket mock now automatically closes all active connections with close code 1012 (Service Restart) so clients reconnect and pick up the new configuration immediately
 - **Workspace-scoped stateful resources** — stateful resources, custom operations, and request logs are now isolated per workspace
 - **`--workspace` persistent CLI flag** — scope any CLI command to a specific workspace without switching context
 - **`?workspaceId=` API parameter** — all admin API endpoints now accept workspace filtering

--- a/docs/src/content/docs/reference/admin-api.md
+++ b/docs/src/content/docs/reference/admin-api.md
@@ -251,6 +251,12 @@ The response includes ports for:
 
 ### Mock Management
 
+:::note[WebSocket: active clients reconnect on mock changes]
+When a WebSocket mock is updated or deleted, all clients currently connected to that endpoint receive a **close frame with code 1012 (Service Restart)**. Most WebSocket client libraries treat code 1012 as a signal to reconnect automatically. On reconnect, the client establishes a fresh connection that uses the new mock configuration.
+
+This applies to `PUT /mocks/{id}`, `DELETE /mocks/{id}`, `POST /mocks/{id}/toggle` (when disabling), bulk `DELETE /mocks` (delete all), and `POST /config` with `replace: true`.
+:::
+
 #### GET /mocks
 
 List all configured mocks.

--- a/pkg/engine/handler_protocol.go
+++ b/pkg/engine/handler_protocol.go
@@ -150,6 +150,13 @@ func (h *Handler) UnregisterWebSocketEndpoint(path string) {
 	h.wsManager.UnregisterEndpoint(path)
 }
 
+// DisconnectWebSocketEndpoint closes all active connections on a WebSocket endpoint.
+// Uses RFC 6455 close code 1012 (Service Restart) so clients reconnect automatically.
+// Must be called before UnregisterWebSocketEndpoint while byEndpoint still tracks the path.
+func (h *Handler) DisconnectWebSocketEndpoint(path string) {
+	h.wsManager.DisconnectByEndpoint(path, websocket.CloseServiceRestart, "mock updated")
+}
+
 // ListSOAPHandlerPaths returns all registered SOAP handler paths.
 func (h *Handler) ListSOAPHandlerPaths() []string {
 	h.soapMu.RLock()

--- a/pkg/engine/mock_manager.go
+++ b/pkg/engine/mock_manager.go
@@ -197,6 +197,11 @@ func (mm *MockManager) unregisterHandlerLocked(cfg *config.MockConfiguration) {
 
 	case mock.TypeWebSocket:
 		if mm.handler != nil && cfg.WebSocket != nil {
+			// Disconnect active clients first so they receive close code 1012
+			// (Service Restart) and reconnect with the new configuration.
+			// Must happen before UnregisterWebSocketEndpoint while byEndpoint
+			// still tracks the path.
+			mm.handler.DisconnectWebSocketEndpoint(cfg.WebSocket.Path)
 			mm.handler.UnregisterWebSocketEndpoint(cfg.WebSocket.Path)
 		}
 	case mock.TypeGraphQL:

--- a/pkg/websocket/manager.go
+++ b/pkg/websocket/manager.go
@@ -102,12 +102,15 @@ func (m *ConnectionManager) RegisterEndpoint(e *Endpoint) {
 }
 
 // UnregisterEndpoint removes an endpoint from the manager.
+// Callers that want active clients to reconnect with new config should call
+// DisconnectByEndpoint before this method, while byEndpoint still tracks
+// the path. The engine's unregisterHandlerLocked does this automatically
+// for every mock update, delete, and clear operation.
 func (m *ConnectionManager) UnregisterEndpoint(path string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	delete(m.endpoints, path)
-	// Note: connections remain until they close
 }
 
 // GetEndpoint returns an endpoint by path.
@@ -253,6 +256,38 @@ func (m *ConnectionManager) CountByEndpoint(path string) int {
 		return len(eps)
 	}
 	return 0
+}
+
+// DisconnectByEndpoint closes all active connections on an endpoint with the given code and reason.
+// Returns the number of connections that were closed.
+//
+// Must be called before UnregisterEndpoint so that byEndpoint still contains the connections.
+// Uses the read-lock/copy pattern (same as BroadcastToEndpoint) to avoid holding the lock
+// while calling conn.Close, which acquires its own lock.
+func (m *ConnectionManager) DisconnectByEndpoint(path string, code CloseCode, reason string) int {
+	m.mu.RLock()
+	var ids []string
+	if eps, ok := m.byEndpoint[path]; ok {
+		ids = make([]string, 0, len(eps))
+		for id := range eps {
+			ids = append(ids, id)
+		}
+	}
+	m.mu.RUnlock()
+
+	closed := 0
+	for _, id := range ids {
+		m.mu.RLock()
+		conn := m.connections[id]
+		m.mu.RUnlock()
+
+		if conn != nil && !conn.IsClosed() {
+			if err := conn.Close(code, reason); err == nil {
+				closed++
+			}
+		}
+	}
+	return closed
 }
 
 // BroadcastToEndpoint sends a message to all connections on an endpoint.

--- a/pkg/websocket/manager_test.go
+++ b/pkg/websocket/manager_test.go
@@ -230,6 +230,55 @@ func TestConnectionManager_ConcurrentJoinFromBothSides(t *testing.T) {
 	}
 }
 
+func TestConnectionManager_DisconnectByEndpoint_UnknownPath(t *testing.T) {
+	manager := NewConnectionManager()
+
+	// Endpoint that was never registered — should return 0 without panicking
+	count := manager.DisconnectByEndpoint("/ws/unknown", CloseServiceRestart, "mock updated")
+	if count != 0 {
+		t.Errorf("expected 0 for unknown path, got %d", count)
+	}
+}
+
+func TestConnectionManager_DisconnectByEndpoint_SkipsAlreadyClosed(t *testing.T) {
+	manager := NewConnectionManager()
+
+	// Pre-closed connection — Close must not be called again (nil conn would panic).
+	conn := &Connection{
+		id:           "conn-already-closed",
+		endpointPath: "/ws/test",
+		groups:       make(map[string]struct{}),
+	}
+	conn.closed.Store(true)
+	manager.Add(conn)
+
+	// All connections already closed → count must be 0.
+	count := manager.DisconnectByEndpoint("/ws/test", CloseServiceRestart, "mock updated")
+	if count != 0 {
+		t.Errorf("expected 0 (connection pre-closed), got %d", count)
+	}
+}
+
+func TestConnectionManager_DisconnectByEndpoint_IsolatesEndpoint(t *testing.T) {
+	manager := NewConnectionManager()
+
+	// Two endpoints: only /ws/target should be affected.
+	target := &Connection{id: "t1", endpointPath: "/ws/target", groups: make(map[string]struct{})}
+	target.closed.Store(true) // pre-close to avoid nil conn panic
+	other := &Connection{id: "o1", endpointPath: "/ws/other", groups: make(map[string]struct{})}
+	other.closed.Store(true)
+
+	manager.Add(target)
+	manager.Add(other)
+
+	manager.DisconnectByEndpoint("/ws/target", CloseServiceRestart, "mock updated")
+
+	// The connection on /ws/other must still be tracked by the manager.
+	if manager.Get("o1") == nil {
+		t.Error("connection on /ws/other should not be removed by DisconnectByEndpoint on /ws/target")
+	}
+}
+
 func TestConnectionManager_BroadcastToGroup(t *testing.T) {
 	manager := NewConnectionManager()
 

--- a/tests/integration/websocket_test.go
+++ b/tests/integration/websocket_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,12 +10,13 @@ import (
 	"time"
 
 	ws "github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/getmockd/mockd/pkg/config"
 	"github.com/getmockd/mockd/pkg/engine"
 	"github.com/getmockd/mockd/pkg/mock"
 	"github.com/getmockd/mockd/pkg/websocket"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // ============================================================================
@@ -797,6 +799,217 @@ func TestWS_FullServer_WithMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ws.MessageText, msgType)
 	assert.Equal(t, testMsg, string(data))
+}
+
+// ============================================================================
+// User Story: Mock Update / Delete Closes Active Connections
+// ============================================================================
+
+// assertCloseCode1012 asserts that readErr is a WebSocket close error with code 1012
+// (Service Restart). Expects readErr to be non-nil (connection already closed by server).
+func assertCloseCode1012(t *testing.T, readErr error) {
+	t.Helper()
+	require.Error(t, readErr, "expected connection to be closed by server")
+	var closeErr ws.CloseError
+	if errors.As(readErr, &closeErr) {
+		assert.Equal(t, ws.StatusCode(websocket.CloseServiceRestart), closeErr.Code,
+			"expected close code 1012 Service Restart")
+	}
+}
+
+// setupWSMockServer creates a test server that has a WebSocket mock registered
+// via the engine's control adapter (not the legacy WebSocketEndpoints collection
+// field). Returns the httptest.Server and a ControlAPIAdapter for mock management.
+func setupWSMockServer(t *testing.T) (*httptest.Server, *engine.ControlAPIAdapter) {
+	t.Helper()
+	cfg := config.DefaultServerConfiguration()
+	srv := engine.NewServer(cfg)
+	adapter := engine.NewControlAPIAdapter(srv)
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close() })
+	return ts, adapter
+}
+
+// TestWS_MockUpdate_ClosesActiveConnections verifies that updating a WebSocket mock
+// sends close code 1012 (Service Restart) to all connected clients so they reconnect
+// and receive the new configuration.
+func TestWS_MockUpdate_ClosesActiveConnections(t *testing.T) {
+	ts, adapter := setupWSMockServer(t)
+
+	// Create initial WebSocket mock.
+	initialResponse := &mock.WSMessageResponse{Type: "text", Value: "v1"}
+	mockCfg := &mock.Mock{
+		Type: mock.TypeWebSocket,
+		WebSocket: &mock.WebSocketSpec{
+			Path:            "/ws/update-test",
+			DefaultResponse: initialResponse,
+		},
+	}
+	require.NoError(t, adapter.AddMock(mockCfg))
+
+	// Connect a WebSocket client.
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/update-test"
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+
+	conn, resp, err := ws.Dial(dialCtx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	require.NoError(t, err, "WebSocket dial failed")
+
+	// Wait for connection to be tracked.
+	time.Sleep(50 * time.Millisecond)
+
+	wsm := getWSManager(t, ts)
+	assert.Equal(t, 1, wsm.CountByEndpoint("/ws/update-test"), "expected 1 active connection before update")
+
+	// Update the mock — this should trigger disconnect of all active clients.
+	mocks := adapter.ListMocks()
+	require.Len(t, mocks, 1)
+	updated := *mocks[0]
+	updated.WebSocket = &mock.WebSocketSpec{
+		Path:            "/ws/update-test",
+		DefaultResponse: &mock.WSMessageResponse{Type: "text", Value: "v2"},
+	}
+	require.NoError(t, adapter.UpdateMock(updated.ID, &updated))
+
+	// The client must receive a close frame with code 1012 Service Restart.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+
+	_, _, readErr := conn.Read(readCtx)
+	require.Error(t, readErr, "expected connection to be closed by server")
+
+	var closeErr ws.CloseError
+	if errors.As(readErr, &closeErr) {
+		assert.Equal(t, ws.StatusCode(websocket.CloseServiceRestart), closeErr.Code,
+			"expected close code 1012 Service Restart")
+	}
+}
+
+// TestWS_MockDelete_ClosesActiveConnections verifies that deleting a WebSocket mock
+// sends close code 1012 (Service Restart) to all connected clients.
+func TestWS_MockDelete_ClosesActiveConnections(t *testing.T) {
+	ts, adapter := setupWSMockServer(t)
+
+	mockCfg := &mock.Mock{
+		Type: mock.TypeWebSocket,
+		WebSocket: &mock.WebSocketSpec{
+			Path: "/ws/delete-test",
+		},
+	}
+	require.NoError(t, adapter.AddMock(mockCfg))
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/delete-test"
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+
+	conn, resp, err := ws.Dial(dialCtx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	require.NoError(t, err, "WebSocket dial failed")
+
+	// Wait for connection to be tracked.
+	time.Sleep(50 * time.Millisecond)
+
+	// Delete the mock — active clients should receive close code 1012.
+	mocks := adapter.ListMocks()
+	require.Len(t, mocks, 1)
+	require.NoError(t, adapter.DeleteMock(mocks[0].ID))
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+
+	_, _, readErr := conn.Read(readCtx)
+	require.Error(t, readErr, "expected connection to be closed by server")
+
+	var closeErr ws.CloseError
+	if errors.As(readErr, &closeErr) {
+		assert.Equal(t, ws.StatusCode(websocket.CloseServiceRestart), closeErr.Code,
+			"expected close code 1012 Service Restart")
+	}
+}
+
+// TestWS_MockToggleDisable_ClosesActiveConnections verifies that disabling a WebSocket
+// mock (toggle to enabled=false) sends close code 1012 to all connected clients.
+// This covers the path: POST /mocks/{id}/toggle → UpdateMock → unregisterHandlerLocked.
+func TestWS_MockToggleDisable_ClosesActiveConnections(t *testing.T) {
+	ts, adapter := setupWSMockServer(t)
+
+	mockCfg := &mock.Mock{
+		Type: mock.TypeWebSocket,
+		WebSocket: &mock.WebSocketSpec{
+			Path: "/ws/toggle-test",
+		},
+	}
+	require.NoError(t, adapter.AddMock(mockCfg))
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/toggle-test"
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+
+	conn, resp, err := ws.Dial(dialCtx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	require.NoError(t, err, "WebSocket dial failed")
+
+	// Wait for connection to be tracked.
+	time.Sleep(50 * time.Millisecond)
+
+	// Disable the mock — active clients should receive close code 1012.
+	mocks := adapter.ListMocks()
+	require.Len(t, mocks, 1)
+	disabled := *mocks[0]
+	enabled := false
+	disabled.Enabled = &enabled
+	require.NoError(t, adapter.UpdateMock(disabled.ID, &disabled))
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+
+	_, _, readErr := conn.Read(readCtx)
+	assertCloseCode1012(t, readErr)
+}
+
+// TestWS_ClearMocks_ClosesActiveConnections verifies that clearing all mocks
+// sends close code 1012 to all connected WebSocket clients.
+// This covers the path used by bulk DELETE /mocks and POST /config?replace=true.
+func TestWS_ClearMocks_ClosesActiveConnections(t *testing.T) {
+	ts, adapter := setupWSMockServer(t)
+
+	mockCfg := &mock.Mock{
+		Type: mock.TypeWebSocket,
+		WebSocket: &mock.WebSocketSpec{
+			Path: "/ws/clear-test",
+		},
+	}
+	require.NoError(t, adapter.AddMock(mockCfg))
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/clear-test"
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+
+	conn, resp, err := ws.Dial(dialCtx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	require.NoError(t, err, "WebSocket dial failed")
+
+	// Wait for connection to be tracked.
+	time.Sleep(50 * time.Millisecond)
+
+	// Clear all mocks — the WebSocket client must receive close code 1012.
+	adapter.ClearMocks()
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+
+	_, _, readErr := conn.Read(readCtx)
+	assertCloseCode1012(t, readErr)
 }
 
 // itoa converts int to string without importing strconv.


### PR DESCRIPTION
## Description
Automatically disconnect active WebSocket clients with close code **1012 (Service Restart)** whenever a WebSocket mock is updated or removed. Before this change, clients kept the old connection alive after a mock config change; after this change, they receive a clean close frame and reconnect with the new configuration.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Related Issues
Fixes #10

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run `go fmt` and `go vet`
- [x] I have added tests covering my changes
- [x] All new and existing tests pass (`go test ./...`)
- [x] I have updated documentation if needed
- [x] I have checked for breaking changes

## Testing
Unit and Integration tests. Manually by Postman.
