### PR TITLE
fix: embed dashboard UI in Docker image

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Install Apache Bench

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Run golangci-lint
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Download dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Install govulncheck
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Run E2E tests
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Build binary
@@ -321,7 +321,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Build

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,8 +62,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASHBOARD_PAT }}
         run: |
+          TAG="${{ github.ref_name }}"
           mkdir -p pkg/admin/dashboard/dist
-          gh release download --repo getmockd/mockd-desktop \
+          # Try matching mockd tag first, then fall back to latest stable release.
+          gh release download "$TAG" --repo getmockd/mockd-desktop \
+            --pattern 'dashboard-dist.tar.gz' \
+            --dir /tmp/dashboard 2>/dev/null \
+          || gh release download --repo getmockd/mockd-desktop \
             --pattern 'dashboard-dist.tar.gz' \
             --dir /tmp/dashboard 2>/dev/null \
           || { echo "::warning::Dashboard dist not found — building without embedded UI"; exit 0; }

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -58,6 +58,19 @@ jobs:
           fi
           echo "commit=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch dashboard dist
+        env:
+          GH_TOKEN: ${{ secrets.DASHBOARD_PAT }}
+        run: |
+          mkdir -p pkg/admin/dashboard/dist
+          gh release download --repo getmockd/mockd-desktop \
+            --pattern 'dashboard-dist.tar.gz' \
+            --dir /tmp/dashboard 2>/dev/null \
+          || { echo "::warning::Dashboard dist not found — building without embedded UI"; exit 0; }
+          tar -xzf /tmp/dashboard/dashboard-dist.tar.gz -C pkg/admin/dashboard/dist/
+          echo "Dashboard dist installed from mockd-desktop:"
+          ls -la pkg/admin/dashboard/dist/
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY . .
 # TARGETARCH is automatically set by Docker buildx for multi-platform builds
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -tags dashboard \
     -ldflags="-s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT}" \
     -trimpath \
     -o mockd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # =============================================================================
 # Stage 1: Builder
 # =============================================================================
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 # Build arguments for version info
 ARG VERSION=dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getmockd/mockd
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/beevik/etree v1.6.0


### PR DESCRIPTION
## Summary

- Docker images built from `main` pushes were missing the admin dashboard UI (404 on admin page) because the build didn't include the web UI assets or the required build tag
- Tagged release images (e.g. `v0.6.4`) worked fine since the release pipeline handles this correctly
- The Docker workflow now fetches the pre-built dashboard dist and builds with `-tags dashboard` so the web UI is properly embedded in all CI-built images

Closes #14

## Test plan

- [x] CI passes on this PR
- [ ] Verify the resulting Docker image serves the admin UI on the admin port instead of returning 404