### PR TITLE
fix: scope stateful resources and custom operations to workspaces (#12)

### DIFF
--- a/pkg/admin/engine_fanout.go
+++ b/pkg/admin/engine_fanout.go
@@ -278,7 +278,11 @@ func (a *API) pushToggleToEngines(ctx context.Context, id string, enabled bool) 
 
 // pushImportToEngines sends an ImportConfig to all engine targets in parallel.
 // Returns the result from the local engine (if any), or the first remote result.
-func (a *API) pushImportToEngines(ctx context.Context, collection *config.MockCollection, replace bool) (*engineclient.ImportResult, error) {
+//
+// workspaceID is forwarded to each engine so stateful resources and custom
+// operations are registered under the correct workspace bucket. An empty
+// workspaceID means the default workspace.
+func (a *API) pushImportToEngines(ctx context.Context, collection *config.MockCollection, replace bool, workspaceID string) (*engineclient.ImportResult, error) {
 	targets := a.allEngineTargets()
 	if len(targets) == 0 {
 		return &engineclient.ImportResult{Imported: 0, Total: len(collection.Mocks)}, nil
@@ -306,7 +310,7 @@ func (a *API) pushImportToEngines(ctx context.Context, collection *config.MockCo
 	}
 
 	if len(targets) == 1 && targets[0].label == "local" {
-		return targets[0].client.ImportConfig(ctx, engineCollection, replace)
+		return targets[0].client.ImportConfig(ctx, engineCollection, replace, workspaceID)
 	}
 
 	type importResult struct {
@@ -318,7 +322,7 @@ func (a *API) pushImportToEngines(ctx context.Context, collection *config.MockCo
 
 	for _, t := range targets {
 		go func(t engineTarget) {
-			res, err := t.client.ImportConfig(ctx, engineCollection, replace)
+			res, err := t.client.ImportConfig(ctx, engineCollection, replace, workspaceID)
 			results <- importResult{label: t.label, result: res, err: err}
 		}(t)
 	}

--- a/pkg/admin/engine_handlers.go
+++ b/pkg/admin/engine_handlers.go
@@ -827,7 +827,10 @@ func (a *API) syncAdminStoreToEngine(client *engineclient.Client, reason string)
 		"customOperations", len(customOps),
 	)
 
-	result, err := client.ImportConfig(ctx, collection, true)
+	// NOTE(#12): the file store does not yet bucket stateful resources or custom
+	// operations by workspace, so on sync everything is pushed under the default
+	// workspace. Per-workspace persistence is tracked as a follow-up to issue #12.
+	result, err := client.ImportConfig(ctx, collection, true, store.DefaultWorkspaceID)
 	if err != nil {
 		a.logger().Warn("sync: failed to push admin store to engine",
 			"error", err, "reason", reason,

--- a/pkg/admin/engineclient/client.go
+++ b/pkg/admin/engineclient/client.go
@@ -432,12 +432,20 @@ type ImportResult struct {
 
 // ImportConfig imports a configuration to the engine and returns the result
 // including any per-mock errors that occurred during import.
-func (c *Client) ImportConfig(ctx context.Context, collection *config.MockCollection, replace bool) (*ImportResult, error) {
+//
+// workspaceID is forwarded as the ?workspaceId= query parameter so the engine
+// registers stateful resources and custom operations under the correct
+// workspace bucket. An empty workspaceID means the default workspace.
+func (c *Client) ImportConfig(ctx context.Context, collection *config.MockCollection, replace bool, workspaceID string) (*ImportResult, error) {
 	body := map[string]interface{}{
 		"config":  collection,
 		"replace": replace,
 	}
-	resp, err := c.post(ctx, "/config", body)
+	path := "/config"
+	if workspaceID != "" {
+		path += "?workspaceId=" + url.QueryEscape(workspaceID)
+	}
+	resp, err := c.post(ctx, path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admin/engineclient/client_test.go
+++ b/pkg/admin/engineclient/client_test.go
@@ -578,7 +578,7 @@ func TestExportConfig_EmptyName(t *testing.T) {
 func TestImportConfig_Success(t *testing.T) {
 	_, c := mockServer(t, jsonHandler(t, 200, map[string]any{"imported": 1, "total": 1}))
 
-	result, err := c.ImportConfig(context.Background(), &config.MockCollection{Name: "test"}, false)
+	result, err := c.ImportConfig(context.Background(), &config.MockCollection{Name: "test"}, false, "")
 	if err != nil {
 		t.Errorf("ImportConfig() error = %v, want nil", err)
 	}
@@ -593,9 +593,42 @@ func TestImportConfig_Success(t *testing.T) {
 func TestImportConfig_Error(t *testing.T) {
 	_, c := mockServer(t, jsonHandler(t, 400, ErrorResponse{Error: "bad_request", Message: "invalid config"}))
 
-	_, err := c.ImportConfig(context.Background(), &config.MockCollection{}, false)
+	_, err := c.ImportConfig(context.Background(), &config.MockCollection{}, false, "")
 	if err == nil {
 		t.Error("ImportConfig() error = nil, want error for 400")
+	}
+}
+
+// TestImportConfig_WorkspaceIDInQuery is a regression test for issue #12.
+// When a workspaceID is passed, it must be forwarded to the engine as the
+// ?workspaceId= query parameter so the engine registers stateful resources and
+// custom operations under the correct workspace bucket. Without this, lookups
+// by mock.WorkspaceID at request time return nil and the request 404s.
+func TestImportConfig_WorkspaceIDInQuery(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query().Get("workspaceId")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"imported":1,"total":1}`))
+	}))
+	t.Cleanup(ts.Close)
+	c := New(ts.URL)
+
+	if _, err := c.ImportConfig(context.Background(), &config.MockCollection{Name: "test"}, false, "exchange-a"); err != nil {
+		t.Fatalf("ImportConfig() error = %v, want nil", err)
+	}
+	if capturedQuery != "exchange-a" {
+		t.Errorf("engine received workspaceId = %q, want %q", capturedQuery, "exchange-a")
+	}
+
+	// Empty workspaceID must NOT add the query parameter (preserve current default behavior).
+	capturedQuery = "sentinel"
+	if _, err := c.ImportConfig(context.Background(), &config.MockCollection{Name: "test"}, false, ""); err != nil {
+		t.Fatalf("ImportConfig() error = %v, want nil", err)
+	}
+	if capturedQuery != "" {
+		t.Errorf("engine received workspaceId = %q for empty workspaceID, want empty", capturedQuery)
 	}
 }
 

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -270,26 +270,36 @@ func (a *API) decodeImportRequest(w http.ResponseWriter, r *http.Request) (*Conf
 
 // persistStatefulResources dual-writes stateful resources from the imported
 // config into the file store so they survive restarts.
-func (a *API) persistStatefulResources(ctx context.Context, cfg *config.MockCollection, replace bool) {
+//
+// Each resource is stamped with workspaceID before persistence so the (workspace,
+// name) identity is preserved. When replace is true, only resources in the
+// target workspace are cleared — other workspaces are left untouched.
+func (a *API) persistStatefulResources(ctx context.Context, cfg *config.MockCollection, replace bool, workspaceID string) {
 	if len(cfg.StatefulResources) == 0 || a.dataStore == nil {
 		return
 	}
 	resStore := a.dataStore.StatefulResources()
 	if replace {
-		_ = resStore.DeleteAll(ctx)
+		_ = resStore.DeleteAll(ctx, workspaceID)
 	}
 	for _, res := range cfg.StatefulResources {
 		if res == nil {
 			continue
 		}
+		// Stamp the workspace if the imported config didn't pin one explicitly,
+		// so the file store records (workspaceID, name) as identity (issue #12).
+		if res.Workspace == "" {
+			res.Workspace = workspaceID
+		}
 		if err := resStore.Create(ctx, res); err != nil {
 			if errors.Is(err, store.ErrAlreadyExists) {
-				// Resource already exists; on replace we already cleared, so this
-				// shouldn't happen, but handle gracefully.
-				a.logger().Debug("stateful resource already exists in file store", "name", res.Name)
+				// Resource already exists in this workspace; on replace we already
+				// cleared, so this shouldn't happen, but handle gracefully.
+				a.logger().Debug("stateful resource already exists in file store",
+					"name", res.Name, "workspace", res.Workspace)
 			} else {
 				a.logger().Warn("failed to write stateful resource to file store",
-					"name", res.Name, "error", err)
+					"name", res.Name, "workspace", res.Workspace, "error", err)
 			}
 		}
 	}
@@ -297,24 +307,34 @@ func (a *API) persistStatefulResources(ctx context.Context, cfg *config.MockColl
 
 // persistCustomOperations dual-writes custom operations from the imported
 // config into the file store so they survive restarts.
-func (a *API) persistCustomOperations(ctx context.Context, cfg *config.MockCollection, replace bool) {
+//
+// Each operation is stamped with workspaceID before persistence so the
+// (workspace, name) identity is preserved. When replace is true, only operations
+// in the target workspace are cleared — other workspaces are left untouched.
+func (a *API) persistCustomOperations(ctx context.Context, cfg *config.MockCollection, replace bool, workspaceID string) {
 	if len(cfg.CustomOperations) == 0 || a.dataStore == nil {
 		return
 	}
 	opStore := a.dataStore.CustomOperations()
 	if replace {
-		_ = opStore.DeleteAll(ctx)
+		_ = opStore.DeleteAll(ctx, workspaceID)
 	}
 	for _, op := range cfg.CustomOperations {
 		if op == nil {
 			continue
 		}
+		// Stamp the workspace if the imported config didn't pin one explicitly
+		// (issue #12).
+		if op.Workspace == "" {
+			op.Workspace = workspaceID
+		}
 		if err := opStore.Create(ctx, op); err != nil {
 			if errors.Is(err, store.ErrAlreadyExists) {
-				a.logger().Debug("custom operation already exists in file store", "name", op.Name)
+				a.logger().Debug("custom operation already exists in file store",
+					"name", op.Name, "workspace", op.Workspace)
 			} else {
 				a.logger().Warn("failed to write custom operation to file store",
-					"name", op.Name, "error", err)
+					"name", op.Name, "workspace", op.Workspace, "error", err)
 			}
 		}
 	}
@@ -407,9 +427,11 @@ func (a *API) handleImportConfig(w http.ResponseWriter, r *http.Request, engine 
 	}
 
 	// If replacing, clear the file store first so we don't leave stale entries.
+	// Scope the deletion to the target workspace — a replace import into one
+	// workspace must NOT delete mocks belonging to other workspaces (issue #12,
+	// same class as the stateful resource fix).
 	if req.Replace && mockStore != nil {
-		// Delete all existing mocks from the file store in this workspace.
-		existing, _ := mockStore.List(ctx, nil)
+		existing, _ := mockStore.List(ctx, &store.MockFilter{WorkspaceID: workspaceID})
 		for _, em := range existing {
 			_ = mockStore.Delete(ctx, em.ID)
 		}
@@ -441,9 +463,10 @@ func (a *API) handleImportConfig(w http.ResponseWriter, r *http.Request, engine 
 	}
 
 	// Dual-write stateful resources to the file store so they survive restarts.
-	a.persistStatefulResources(ctx, req.Config, req.Replace)
+	// Pass workspaceID so each entry is bucketed correctly (issue #12).
+	a.persistStatefulResources(ctx, req.Config, req.Replace, workspaceID)
 	// Dual-write custom operations to the file store so they survive restarts.
-	a.persistCustomOperations(ctx, req.Config, req.Replace)
+	a.persistCustomOperations(ctx, req.Config, req.Replace, workspaceID)
 
 	// Pre-validate mocks so we can surface which mock (by index) is invalid.
 	if err := preValidateImportMocks(req.Config.Mocks); err != nil {
@@ -452,7 +475,10 @@ func (a *API) handleImportConfig(w http.ResponseWriter, r *http.Request, engine 
 	}
 
 	// Forward to engine for runtime registration (starts gRPC/MQTT servers, registers handlers).
-	importResult, err := engine.ImportConfig(ctx, req.Config, req.Replace)
+	// Pass workspaceID so the engine registers stateful resources and custom operations
+	// under the active workspace bucket — otherwise lookups by mock.WorkspaceID fail at
+	// request time (issue #12).
+	importResult, err := engine.ImportConfig(ctx, req.Config, req.Replace, workspaceID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_error", sanitizeError(err, a.logger(), "import config"))
 		return
@@ -538,18 +564,20 @@ func (a *API) ImportConfigDirect(ctx context.Context, collection *config.MockCol
 		}
 	}
 
-	// Persist stateful resources
-	a.persistStatefulResources(ctx, collection, replace)
-	// Persist custom operations
-	a.persistCustomOperations(ctx, collection, replace)
+	// Persist stateful resources to the default workspace bucket. Per-workspace
+	// imports go through the HTTP path (handleImportConfig).
+	a.persistStatefulResources(ctx, collection, replace, store.DefaultWorkspaceID)
+	// Persist custom operations to the default workspace bucket.
+	a.persistCustomOperations(ctx, collection, replace, store.DefaultWorkspaceID)
 
 	// Pre-validate before sending to engine
 	if err := preValidateImportMocks(collection.Mocks); err != nil {
 		return 0, err
 	}
 
-	// Forward to all engines for runtime registration
-	importResult, err := a.pushImportToEngines(ctx, collection, replace)
+	// Forward to all engines for runtime registration. Initial config load uses
+	// the default workspace; per-workspace imports go through the HTTP path.
+	importResult, err := a.pushImportToEngines(ctx, collection, replace, store.DefaultWorkspaceID)
 	if err != nil {
 		return 0, fmt.Errorf("engine import failed: %w", err)
 	}

--- a/pkg/admin/handlers_test.go
+++ b/pkg/admin/handlers_test.go
@@ -639,6 +639,160 @@ func TestHandleImportConfig(t *testing.T) {
 		assert.True(t, *stored.Enabled, "imported mock should default to enabled")
 	})
 
+	// Regression test for issue #12: when importing into a named workspace,
+	// the workspaceId query parameter must be forwarded to the engine so
+	// stateful resources and custom operations are registered under the
+	// correct workspace bucket. Otherwise lookups by mock.WorkspaceID at
+	// request time return nil and the request 404s.
+	t.Run("forwards workspaceId query parameter to engine on import (issue #12)", func(t *testing.T) {
+		var capturedQuery string
+		var captured sync.Once
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/config" {
+				captured.Do(func() {
+					capturedQuery = r.URL.Query().Get("workspaceId")
+				})
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{"imported":1,"total":1}`))
+				return
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer ts.Close()
+
+		api := NewAPI(0,
+			WithDataDir(t.TempDir()),
+			WithLocalEngineClient(engineclient.New(ts.URL)),
+		)
+
+		importData := map[string]interface{}{
+			"config": map[string]interface{}{
+				"version": "1.0",
+				"mocks": []map[string]interface{}{
+					{
+						"id":   "place-order",
+						"name": "Place Order",
+						"type": "http",
+					},
+				},
+				"statefulResources": []map[string]interface{}{
+					{"name": "orders", "idField": "id"},
+				},
+			},
+			"replace": false,
+		}
+		body, _ := json.Marshal(importData)
+
+		req := httptest.NewRequest("POST", "/config?workspaceId=exchange-a", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		api.handleImportConfig(rec, req, engineclient.New(ts.URL))
+
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		assert.Equal(t, "exchange-a", capturedQuery,
+			"engine must receive workspaceId so stateful resources register under the active workspace")
+	})
+
+	// Regression test for issue #12: importing with replace=true into one
+	// workspace must NOT clear stateful resources or custom operations
+	// belonging to OTHER workspaces. Without per-workspace DeleteAll scoping,
+	// a replace import would silently nuke unrelated workspaces' state.
+	t.Run("replace import preserves other workspaces' resources (issue #12)", func(t *testing.T) {
+		server := newMockEngineServer()
+		defer server.Close()
+
+		api := NewAPI(0,
+			WithDataDir(t.TempDir()),
+			WithLocalEngineClient(server.client()),
+		)
+		ctx := t.Context()
+
+		// Pre-populate the file store with resources and operations in workspace ws-other.
+		require.NoError(t, api.dataStore.StatefulResources().Create(ctx, &config.StatefulResourceConfig{
+			Name: "products", Workspace: "ws-other",
+		}))
+		require.NoError(t, api.dataStore.CustomOperations().Create(ctx, &config.CustomOperationConfig{
+			Name: "RestockProduct", Workspace: "ws-other",
+		}))
+		// Also add a same-named "orders" resource in a third workspace to confirm
+		// it stays untouched even though ws-target is also importing "orders".
+		require.NoError(t, api.dataStore.StatefulResources().Create(ctx, &config.StatefulResourceConfig{
+			Name: "orders", Workspace: "ws-third",
+		}))
+		// And a pre-existing mock in ws-other to verify mock-replace is also
+		// scoped to the target workspace (handlers.go replace block).
+		require.NoError(t, api.dataStore.Mocks().Create(ctx, &config.MockConfiguration{
+			ID: "ws-other-mock", Type: mock.TypeHTTP, WorkspaceID: "ws-other",
+		}))
+
+		// Import with replace=true into ws-target.
+		importData := map[string]interface{}{
+			"config": map[string]interface{}{
+				"version": "1.0",
+				"mocks": []map[string]interface{}{{
+					"id": "place-order", "type": "http",
+					"http": map[string]interface{}{
+						"matcher": map[string]interface{}{"method": "POST", "path": "/orders"},
+						"response": map[string]interface{}{"statusCode": 200, "body": "ok"},
+					},
+				}},
+				"statefulResources": []map[string]interface{}{{"name": "orders", "idField": "id"}},
+				"customOperations":  []map[string]interface{}{{"name": "CancelOrder"}},
+			},
+			"replace": true,
+		}
+		body, _ := json.Marshal(importData)
+		req := httptest.NewRequest("POST", "/config?workspaceId=ws-target", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		api.handleImportConfig(rec, req, server.client())
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+		// ws-other's resources/operations must still be present.
+		resources, err := api.dataStore.StatefulResources().List(ctx)
+		require.NoError(t, err)
+		var (
+			otherProducts  bool
+			thirdOrders    bool
+			targetOrders   bool
+		)
+		for _, r := range resources {
+			switch {
+			case r.Name == "products" && r.Workspace == "ws-other":
+				otherProducts = true
+			case r.Name == "orders" && r.Workspace == "ws-third":
+				thirdOrders = true
+			case r.Name == "orders" && r.Workspace == "ws-target":
+				targetOrders = true
+			}
+		}
+		assert.True(t, otherProducts, "ws-other 'products' should survive replace into ws-target")
+		assert.True(t, thirdOrders, "ws-third 'orders' should survive replace into ws-target (same name, different workspace)")
+		assert.True(t, targetOrders, "ws-target should have its newly-imported 'orders'")
+
+		ops, err := api.dataStore.CustomOperations().List(ctx)
+		require.NoError(t, err)
+		var otherRestock, targetCancel bool
+		for _, op := range ops {
+			if op.Name == "RestockProduct" && op.Workspace == "ws-other" {
+				otherRestock = true
+			}
+			if op.Name == "CancelOrder" && op.Workspace == "ws-target" {
+				targetCancel = true
+			}
+		}
+		assert.True(t, otherRestock, "ws-other 'RestockProduct' op should survive replace into ws-target")
+		assert.True(t, targetCancel, "ws-target should have its newly-imported 'CancelOrder' op")
+
+		// And the pre-existing ws-other mock must still be there.
+		stored, err := api.dataStore.Mocks().Get(ctx, "ws-other-mock")
+		require.NoError(t, err, "ws-other-mock should survive replace import into ws-target")
+		assert.Equal(t, "ws-other", stored.WorkspaceID)
+	})
+
 	t.Run("returns error when no engine connected", func(t *testing.T) {
 		api := NewAPI(0, WithDataDir(t.TempDir()))
 

--- a/pkg/admin/stateful_handlers.go
+++ b/pkg/admin/stateful_handlers.go
@@ -143,6 +143,9 @@ func (a *API) handleCreateStateResource(w http.ResponseWriter, r *http.Request, 
 	// survives restarts. If persistence fails (e.g., stale duplicate in
 	// data.json), log a warning but don't error — the engine is authoritative.
 	if a.dataStore != nil {
+		// Stamp the workspace so the file store records (workspace, name) as
+		// identity (issue #12). The engine already registered under workspaceID.
+		cfg.Workspace = workspaceID
 		resStore := a.dataStore.StatefulResources()
 		if err := resStore.Create(ctx, &cfg); err != nil {
 			if errors.Is(err, store.ErrAlreadyExists) {
@@ -183,8 +186,9 @@ func (a *API) handleDeleteStateResource(w http.ResponseWriter, r *http.Request, 
 	// Remove from the file store so it doesn't reload on restart.
 	if a.dataStore != nil {
 		resStore := a.dataStore.StatefulResources()
-		if err := resStore.Delete(ctx, name); err != nil {
-			a.logger().Warn("failed to delete stateful resource from store", "name", name, "error", err)
+		if err := resStore.Delete(ctx, workspaceID, name); err != nil {
+			a.logger().Warn("failed to delete stateful resource from store",
+				"name", name, "workspace", workspaceID, "error", err)
 		}
 	}
 
@@ -459,13 +463,17 @@ func (a *API) handleRegisterCustomOperation(w http.ResponseWriter, r *http.Reque
 		if marshalErr == nil {
 			var opCfg config.CustomOperationConfig
 			if unmarshalErr := json.Unmarshal(rawBytes, &opCfg); unmarshalErr == nil && opCfg.Name != "" {
+				// Stamp the workspace so the file store records (workspace, name) as
+				// identity (issue #12).
+				opCfg.Workspace = workspaceID
 				if createErr := opStore.Create(ctx, &opCfg); createErr != nil {
 					if errors.Is(createErr, store.ErrAlreadyExists) {
-						// Update: delete then re-create
-						_ = opStore.Delete(ctx, opCfg.Name)
+						// Update: delete then re-create within this workspace.
+						_ = opStore.Delete(ctx, workspaceID, opCfg.Name)
 						_ = opStore.Create(ctx, &opCfg)
 					} else {
-						a.logger().Warn("failed to persist custom operation", "name", name, "error", createErr)
+						a.logger().Warn("failed to persist custom operation",
+							"name", name, "workspace", workspaceID, "error", createErr)
 					}
 				}
 			}
@@ -499,9 +507,10 @@ func (a *API) handleDeleteCustomOperation(w http.ResponseWriter, r *http.Request
 
 	// Remove from file store.
 	if a.dataStore != nil {
-		if delErr := a.dataStore.CustomOperations().Delete(ctx, name); delErr != nil {
+		if delErr := a.dataStore.CustomOperations().Delete(ctx, workspaceID, name); delErr != nil {
 			if !errors.Is(delErr, store.ErrNotFound) {
-				a.logger().Warn("failed to remove custom operation from file store", "name", name, "error", delErr)
+				a.logger().Warn("failed to remove custom operation from file store",
+					"name", name, "workspace", workspaceID, "error", delErr)
 			}
 		}
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -200,6 +200,14 @@ func runStart(cmd *cobra.Command, args []string) error {
 			server.SetStore(persistentStore)
 			// Ensure store is closed on shutdown
 			defer func() { _ = persistentStore.Close() }()
+			// Restore persisted stateful resources and custom operations into the
+			// runtime engine — mocks are loaded lazily via PersistentMockStore but
+			// stateful resources/custom operations need explicit re-registration so
+			// requests can resolve their (workspaceID, name) buckets after restart
+			// (issue #12).
+			if err := server.LoadFromStore(context.Background()); err != nil {
+				output.Warn("failed to load persisted state from store: %v", err)
+			}
 		}
 	}
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -344,9 +344,13 @@ type WebSocketEndpointConfig struct {
 // StatefulResourceConfig defines configuration for a stateful CRUD resource.
 // This is the single canonical type used in YAML config, persistence, and API transport.
 type StatefulResourceConfig struct {
-	// Name is the unique resource name (e.g., "users", "products")
+	// Name is the unique resource name within a workspace (e.g., "users", "products").
+	// Two workspaces may each register a resource with the same name.
 	Name string `json:"name" yaml:"name"`
-	// Workspace is the workspace this resource belongs to (YAML config only, not persisted)
+	// Workspace is the workspace this resource belongs to. An empty value means
+	// the default workspace. This field is persisted and used as part of the
+	// resource's identity (workspaceID, name) by both the file store and the
+	// runtime StateStore.
 	Workspace string `json:"workspace,omitempty" yaml:"workspace,omitempty"`
 	// IDField is the field name for ID (default: "id")
 	IDField string `json:"idField,omitempty" yaml:"idField,omitempty"`
@@ -510,8 +514,15 @@ type ErrorTransform struct {
 //	    response:
 //	      status: '"completed"'
 type CustomOperationConfig struct {
-	// Name is the unique operation name (referenced in SOAP/GraphQL/gRPC configs)
+	// Name is the unique operation name within a workspace (referenced in
+	// SOAP/GraphQL/gRPC configs). Two workspaces may each register an operation
+	// with the same name.
 	Name string `json:"name" yaml:"name"`
+	// Workspace is the workspace this operation belongs to. An empty value means
+	// the default workspace. This field is persisted and used as part of the
+	// operation's identity (workspaceID, name) by both the file store and the
+	// runtime Bridge.
+	Workspace string `json:"workspace,omitempty" yaml:"workspace,omitempty"`
 	// Consistency controls execution semantics: "best_effort" (default) or "atomic".
 	// "atomic" rolls back prior mutations in the operation if a later step fails.
 	Consistency string `json:"consistency,omitempty" yaml:"consistency,omitempty"`

--- a/pkg/engine/api/handlers.go
+++ b/pkg/engine/api/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getmockd/mockd/pkg/httputil"
 	"github.com/getmockd/mockd/pkg/requestlog"
 	"github.com/getmockd/mockd/pkg/stateful"
+	"github.com/getmockd/mockd/pkg/store"
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -880,27 +881,69 @@ func (s *Server) handleImportConfig(w http.ResponseWriter, r *http.Request) {
 		imported++
 	}
 
-	// Import stateful resources
+	// Resolve the engine's persistent store once. The engine and admin run as
+	// distinct file.FileStore instances pointed at the same data.json (admin's
+	// dataStore + engine's persistentStore), and whichever one writes last wins
+	// on disk. Mocks survive because both stores write them through their own
+	// paths; stateful resources and custom operations only flow through admin
+	// today, so the engine's stale view used to overwrite admin's freshly-saved
+	// resources on shutdown. Mirror the writes here so both file stores agree
+	// (issue #12).
+	persistentStore := s.engine.PersistentStore()
+
+	// Import stateful resources. Each resource may pin its own workspace via
+	// res.Workspace; the ?workspaceId= query param is the default for entries
+	// that don't (issue #12). This lets a single import payload register
+	// resources spanning multiple workspaces — which is exactly how the admin
+	// sync path replays the file store on startup.
 	statefulCount := 0
 	for _, res := range req.Config.StatefulResources {
-		if res != nil {
-			if err := s.engine.RegisterStatefulResource(workspaceID, res); err != nil {
-				s.log.Warn("failed to import stateful resource", "name", res.Name, "error", err)
-				continue
-			}
-			statefulCount++
+		if res == nil {
+			continue
 		}
+		bucket := res.Workspace
+		if bucket == "" {
+			bucket = workspaceID
+		}
+		if err := s.engine.RegisterStatefulResource(bucket, res); err != nil {
+			s.log.Warn("failed to import stateful resource",
+				"name", res.Name, "workspace", bucket, "error", err)
+			continue
+		}
+		// Stamp the resource's workspace before persisting so reload-from-disk
+		// re-registers it under the correct bucket.
+		res.Workspace = bucket
+		if persistentStore != nil && persistentStore.StatefulResources() != nil {
+			if err := persistentStore.StatefulResources().Create(r.Context(), res); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+				s.log.Warn("failed to persist stateful resource to engine store",
+					"name", res.Name, "workspace", bucket, "error", err)
+			}
+		}
+		statefulCount++
 	}
 
-	// Import custom operations
+	// Import custom operations. Each operation may pin its own workspace via
+	// opCfg.Workspace; the ?workspaceId= query param is the default (issue #12).
 	customOpCount := 0
 	for _, opCfg := range req.Config.CustomOperations {
 		if opCfg == nil {
 			continue
 		}
-		if err := s.engine.RegisterCustomOperation(workspaceID, opCfg); err != nil {
-			s.log.Warn("failed to import custom operation", "name", opCfg.Name, "error", err)
+		bucket := opCfg.Workspace
+		if bucket == "" {
+			bucket = workspaceID
+		}
+		if err := s.engine.RegisterCustomOperation(bucket, opCfg); err != nil {
+			s.log.Warn("failed to import custom operation",
+				"name", opCfg.Name, "workspace", bucket, "error", err)
 			continue
+		}
+		opCfg.Workspace = bucket
+		if persistentStore != nil && persistentStore.CustomOperations() != nil {
+			if err := persistentStore.CustomOperations().Create(r.Context(), opCfg); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+				s.log.Warn("failed to persist custom operation to engine store",
+					"name", opCfg.Name, "workspace", bucket, "error", err)
+			}
 		}
 		customOpCount++
 	}

--- a/pkg/engine/api/handlers_test.go
+++ b/pkg/engine/api/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getmockd/mockd/pkg/mock"
 	"github.com/getmockd/mockd/pkg/requestlog"
 	"github.com/getmockd/mockd/pkg/stateful"
+	"github.com/getmockd/mockd/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -360,6 +361,10 @@ func (m *mockEngine) GetWebSocketStats() *WebSocketStats {
 
 func (m *mockEngine) GetConfig() *ConfigResponse {
 	return m.configResp
+}
+
+func (m *mockEngine) PersistentStore() store.Store {
+	return nil
 }
 
 func (m *mockEngine) ListCustomOperations(workspaceID string) []CustomOperationInfo {

--- a/pkg/engine/api/server.go
+++ b/pkg/engine/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getmockd/mockd/pkg/config"
 	"github.com/getmockd/mockd/pkg/logging"
 	"github.com/getmockd/mockd/pkg/requestlog"
+	"github.com/getmockd/mockd/pkg/store"
 )
 
 // Server is the Engine Control API server.
@@ -93,6 +94,12 @@ type EngineController interface {
 
 	// Config
 	GetConfig() *ConfigResponse
+
+	// PersistentStore returns the underlying persistent store, if one is wired
+	// up. Used by the import handler to dual-write stateful resources and
+	// custom operations alongside the admin file store (issue #12). May
+	// return nil when no persistent store is configured.
+	PersistentStore() store.Store
 }
 
 // NewServer creates a new Engine Control API server.

--- a/pkg/engine/config_loader.go
+++ b/pkg/engine/config_loader.go
@@ -83,9 +83,9 @@ func (cl *ConfigLoader) LoadFromStore(ctx context.Context, persistentStore store
 				// doesn't poison future add_resource calls with a false
 				// "already exists" from the file store while the engine
 				// has no knowledge of it.
-				if delErr := persistentStore.StatefulResources().Delete(ctx, res.Name); delErr != nil {
+				if delErr := persistentStore.StatefulResources().Delete(ctx, res.Workspace, res.Name); delErr != nil {
 					cl.log.Warn("failed to clean up stale stateful resource from store",
-						"name", res.Name, "error", delErr)
+						"name", res.Name, "workspace", res.Workspace, "error", delErr)
 				}
 				continue
 			}
@@ -109,14 +109,16 @@ func (cl *ConfigLoader) LoadFromStore(ctx context.Context, persistentStore store
 			customOp, convErr := convertCustomOperation(opCfg)
 			if convErr != nil {
 				cl.log.Warn("failed to convert persisted custom operation, removing stale entry",
-					"name", opCfg.Name, "error", convErr)
-				if delErr := persistentStore.CustomOperations().Delete(ctx, opCfg.Name); delErr != nil {
+					"name", opCfg.Name, "workspace", opCfg.Workspace, "error", convErr)
+				if delErr := persistentStore.CustomOperations().Delete(ctx, opCfg.Workspace, opCfg.Name); delErr != nil {
 					cl.log.Warn("failed to clean up stale custom operation from store",
-						"name", opCfg.Name, "error", delErr)
+						"name", opCfg.Name, "workspace", opCfg.Workspace, "error", delErr)
 				}
 				continue
 			}
-			cl.server.statefulBridge.RegisterCustomOperation("", opCfg.Name, customOp)
+			// Register under the persisted workspace bucket so lookups by
+			// mock.WorkspaceID at request time succeed (issue #12).
+			cl.server.statefulBridge.RegisterCustomOperation(opCfg.Workspace, opCfg.Name, customOp)
 			loaded++
 		}
 		if loaded > 0 {

--- a/pkg/engine/control_api.go
+++ b/pkg/engine/control_api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getmockd/mockd/pkg/protocol"
 	"github.com/getmockd/mockd/pkg/requestlog"
 	"github.com/getmockd/mockd/pkg/stateful"
+	"github.com/getmockd/mockd/pkg/store"
 )
 
 // Errors returned by the control API adapter.
@@ -767,6 +768,14 @@ func (a *ControlAPIAdapter) GetWebSocketStats() *api.WebSocketStats {
 		TotalMessagesRecv: stats.TotalMessagesReceived,
 		ConnectionsByMock: connectionsByMock,
 	}
+}
+
+// PersistentStore implements api.EngineController. Returns the engine's
+// underlying persistent store, if any. Used by the import handler to dual-write
+// stateful resources and custom operations alongside the admin file store
+// (issue #12).
+func (a *ControlAPIAdapter) PersistentStore() store.Store {
+	return a.server.PersistentStore()
 }
 
 // GetConfig implements api.EngineController.

--- a/pkg/store/file/custom_operation_store.go
+++ b/pkg/store/file/custom_operation_store.go
@@ -13,7 +13,8 @@ type customOperationStore struct {
 	fs *FileStore
 }
 
-// List returns all persisted custom operation configs.
+// List returns all persisted custom operation configs across every workspace.
+// Each entry's Workspace field identifies its bucket.
 func (s *customOperationStore) List(ctx context.Context) ([]*config.CustomOperationConfig, error) {
 	s.fs.mu.RLock()
 	defer s.fs.mu.RUnlock()
@@ -27,7 +28,8 @@ func (s *customOperationStore) List(ctx context.Context) ([]*config.CustomOperat
 	return result, nil
 }
 
-// Create persists a new custom operation config.
+// Create persists a new custom operation config. Identity is (workspace, name);
+// two workspaces may each register an operation with the same name.
 func (s *customOperationStore) Create(ctx context.Context, op *config.CustomOperationConfig) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
@@ -36,9 +38,9 @@ func (s *customOperationStore) Create(ctx context.Context, op *config.CustomOper
 		return store.ErrReadOnly
 	}
 
-	// Check for duplicate name
+	// Check for duplicate (workspace, name).
 	for _, existing := range s.fs.data.CustomOperations {
-		if existing.Name == op.Name {
+		if existing.Workspace == op.Workspace && existing.Name == op.Name {
 			return store.ErrAlreadyExists
 		}
 	}
@@ -48,8 +50,8 @@ func (s *customOperationStore) Create(ctx context.Context, op *config.CustomOper
 	return nil
 }
 
-// Delete removes a custom operation config by name.
-func (s *customOperationStore) Delete(ctx context.Context, name string) error {
+// Delete removes a custom operation config from the given workspace by name.
+func (s *customOperationStore) Delete(ctx context.Context, workspaceID, name string) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
 
@@ -58,7 +60,7 @@ func (s *customOperationStore) Delete(ctx context.Context, name string) error {
 	}
 
 	for i, op := range s.fs.data.CustomOperations {
-		if op.Name == name {
+		if op.Workspace == workspaceID && op.Name == name {
 			s.fs.data.CustomOperations = append(s.fs.data.CustomOperations[:i], s.fs.data.CustomOperations[i+1:]...)
 			s.fs.markDirty()
 			return nil
@@ -67,8 +69,9 @@ func (s *customOperationStore) Delete(ctx context.Context, name string) error {
 	return store.ErrNotFound
 }
 
-// DeleteAll removes all custom operation configs.
-func (s *customOperationStore) DeleteAll(ctx context.Context) error {
+// DeleteAll removes every custom operation config in the given workspace.
+// Operations in other workspaces are left untouched.
+func (s *customOperationStore) DeleteAll(ctx context.Context, workspaceID string) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
 
@@ -76,7 +79,18 @@ func (s *customOperationStore) DeleteAll(ctx context.Context) error {
 		return store.ErrReadOnly
 	}
 
-	s.fs.data.CustomOperations = nil
-	s.fs.markDirty()
+	kept := s.fs.data.CustomOperations[:0]
+	removed := false
+	for _, op := range s.fs.data.CustomOperations {
+		if op.Workspace == workspaceID {
+			removed = true
+			continue
+		}
+		kept = append(kept, op)
+	}
+	s.fs.data.CustomOperations = kept
+	if removed {
+		s.fs.markDirty()
+	}
 	return nil
 }

--- a/pkg/store/file/custom_operation_store_test.go
+++ b/pkg/store/file/custom_operation_store_test.go
@@ -106,8 +106,8 @@ func TestCustomOperationStore_DeleteByName(t *testing.T) {
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Op2"})
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Op3"})
 
-	// Delete the middle one
-	if err := cos.Delete(ctx, "Op2"); err != nil {
+	// Delete the middle one (default workspace)
+	if err := cos.Delete(ctx, "", "Op2"); err != nil {
 		t.Fatalf("Delete(Op2) failed: %v", err)
 	}
 
@@ -131,7 +131,7 @@ func TestCustomOperationStore_DeleteByName(t *testing.T) {
 func TestCustomOperationStore_DeleteNotFound(t *testing.T) {
 	fs := newTestStore(t)
 	ctx := context.Background()
-	err := fs.CustomOperations().Delete(ctx, "nonexistent")
+	err := fs.CustomOperations().Delete(ctx, "", "nonexistent")
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -146,13 +146,59 @@ func TestCustomOperationStore_DeleteAll_MultipleItems(t *testing.T) {
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "B"})
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "C"})
 
-	if err := cos.DeleteAll(ctx); err != nil {
+	if err := cos.DeleteAll(ctx, ""); err != nil {
 		t.Fatalf("DeleteAll() failed: %v", err)
 	}
 
 	list, _ := cos.List(ctx)
 	if len(list) != 0 {
 		t.Errorf("expected 0 after DeleteAll, got %d", len(list))
+	}
+}
+
+// TestCustomOperationStore_WorkspaceIsolation is a regression test for issue #12.
+// Two workspaces must be able to register custom operations with the same name,
+// and Delete/DeleteAll must be scoped to one workspace at a time.
+func TestCustomOperationStore_WorkspaceIsolation(t *testing.T) {
+	fs := newTestStore(t)
+	ctx := context.Background()
+	cos := fs.CustomOperations()
+
+	// Same name, different workspaces — both must succeed.
+	if err := cos.Create(ctx, &config.CustomOperationConfig{Name: "CancelOrder", Workspace: "ws-a"}); err != nil {
+		t.Fatalf("Create ws-a: %v", err)
+	}
+	if err := cos.Create(ctx, &config.CustomOperationConfig{Name: "CancelOrder", Workspace: "ws-b"}); err != nil {
+		t.Fatalf("Create ws-b: %v", err)
+	}
+	// Same (workspace, name) is a duplicate.
+	if err := cos.Create(ctx, &config.CustomOperationConfig{Name: "CancelOrder", Workspace: "ws-a"}); !errors.Is(err, store.ErrAlreadyExists) {
+		t.Errorf("expected ErrAlreadyExists, got %v", err)
+	}
+
+	// Delete only touches the named workspace.
+	if err := cos.Delete(ctx, "ws-a", "CancelOrder"); err != nil {
+		t.Fatalf("Delete ws-a: %v", err)
+	}
+	list, _ := cos.List(ctx)
+	if len(list) != 1 || list[0].Workspace != "ws-b" {
+		t.Errorf("expected only ws-b CancelOrder to remain, got %+v", list)
+	}
+
+	// DeleteAll is also workspace-scoped.
+	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Refund", Workspace: "ws-b"})
+	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Refund", Workspace: "ws-c"})
+	if err := cos.DeleteAll(ctx, "ws-b"); err != nil {
+		t.Fatalf("DeleteAll ws-b: %v", err)
+	}
+	list, _ = cos.List(ctx)
+	for _, op := range list {
+		if op.Workspace == "ws-b" {
+			t.Errorf("ws-b operation %q should have been deleted", op.Name)
+		}
+	}
+	if len(list) != 1 || list[0].Workspace != "ws-c" {
+		t.Errorf("expected only ws-c Refund to remain, got %+v", list)
 	}
 }
 
@@ -196,10 +242,10 @@ func TestCustomOperationStore_ReadOnly_AllMethods(t *testing.T) {
 	if err := cos.Create(ctx, &config.CustomOperationConfig{Name: "x"}); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Create: expected ErrReadOnly, got %v", err)
 	}
-	if err := cos.Delete(ctx, "x"); !errors.Is(err, store.ErrReadOnly) {
+	if err := cos.Delete(ctx, "", "x"); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Delete: expected ErrReadOnly, got %v", err)
 	}
-	if err := cos.DeleteAll(ctx); !errors.Is(err, store.ErrReadOnly) {
+	if err := cos.DeleteAll(ctx, ""); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("DeleteAll: expected ErrReadOnly, got %v", err)
 	}
 
@@ -333,7 +379,7 @@ func TestCustomOperationStore_PersistenceAfterDelete(t *testing.T) {
 	cos1 := fs1.CustomOperations()
 	_ = cos1.Create(ctx, &config.CustomOperationConfig{Name: "ToKeep"})
 	_ = cos1.Create(ctx, &config.CustomOperationConfig{Name: "ToDelete"})
-	_ = cos1.Delete(ctx, "ToDelete")
+	_ = cos1.Delete(ctx, "", "ToDelete")
 	_ = fs1.Close()
 
 	// Session 2: Only ToKeep should remain

--- a/pkg/store/file/stateful_resource_store.go
+++ b/pkg/store/file/stateful_resource_store.go
@@ -13,7 +13,8 @@ type statefulResourceStore struct {
 	fs *FileStore
 }
 
-// List returns all persisted stateful resource configs.
+// List returns all persisted stateful resource configs across every workspace.
+// Each entry's Workspace field identifies its bucket.
 func (s *statefulResourceStore) List(ctx context.Context) ([]*config.StatefulResourceConfig, error) {
 	s.fs.mu.RLock()
 	defer s.fs.mu.RUnlock()
@@ -27,7 +28,8 @@ func (s *statefulResourceStore) List(ctx context.Context) ([]*config.StatefulRes
 	return result, nil
 }
 
-// Create persists a new stateful resource config.
+// Create persists a new stateful resource config. Identity is (workspace, name);
+// two workspaces may each register a resource with the same name.
 func (s *statefulResourceStore) Create(ctx context.Context, res *config.StatefulResourceConfig) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
@@ -36,9 +38,9 @@ func (s *statefulResourceStore) Create(ctx context.Context, res *config.Stateful
 		return store.ErrReadOnly
 	}
 
-	// Check for duplicate name
+	// Check for duplicate (workspace, name).
 	for _, existing := range s.fs.data.StatefulResources {
-		if existing.Name == res.Name {
+		if existing.Workspace == res.Workspace && existing.Name == res.Name {
 			return store.ErrAlreadyExists
 		}
 	}
@@ -48,8 +50,8 @@ func (s *statefulResourceStore) Create(ctx context.Context, res *config.Stateful
 	return nil
 }
 
-// Delete removes a stateful resource config by name.
-func (s *statefulResourceStore) Delete(ctx context.Context, name string) error {
+// Delete removes a stateful resource config from the given workspace by name.
+func (s *statefulResourceStore) Delete(ctx context.Context, workspaceID, name string) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
 
@@ -58,7 +60,7 @@ func (s *statefulResourceStore) Delete(ctx context.Context, name string) error {
 	}
 
 	for i, res := range s.fs.data.StatefulResources {
-		if res.Name == name {
+		if res.Workspace == workspaceID && res.Name == name {
 			s.fs.data.StatefulResources = append(s.fs.data.StatefulResources[:i], s.fs.data.StatefulResources[i+1:]...)
 			s.fs.markDirty()
 			return nil
@@ -67,8 +69,9 @@ func (s *statefulResourceStore) Delete(ctx context.Context, name string) error {
 	return store.ErrNotFound
 }
 
-// DeleteAll removes all stateful resource configs.
-func (s *statefulResourceStore) DeleteAll(ctx context.Context) error {
+// DeleteAll removes every stateful resource config in the given workspace.
+// Resources in other workspaces are left untouched.
+func (s *statefulResourceStore) DeleteAll(ctx context.Context, workspaceID string) error {
 	s.fs.mu.Lock()
 	defer s.fs.mu.Unlock()
 
@@ -76,7 +79,18 @@ func (s *statefulResourceStore) DeleteAll(ctx context.Context) error {
 		return store.ErrReadOnly
 	}
 
-	s.fs.data.StatefulResources = nil
-	s.fs.markDirty()
+	kept := s.fs.data.StatefulResources[:0]
+	removed := false
+	for _, res := range s.fs.data.StatefulResources {
+		if res.Workspace == workspaceID {
+			removed = true
+			continue
+		}
+		kept = append(kept, res)
+	}
+	s.fs.data.StatefulResources = kept
+	if removed {
+		s.fs.markDirty()
+	}
 	return nil
 }

--- a/pkg/store/file/store_test.go
+++ b/pkg/store/file/store_test.go
@@ -1558,8 +1558,8 @@ func TestStatefulResourceStore_CRUD(t *testing.T) {
 		t.Errorf("expected 'users', got %q", list[0].Name)
 	}
 
-	// Delete by name
-	if err := srs.Delete(ctx, "users"); err != nil {
+	// Delete by (workspace, name)
+	if err := srs.Delete(ctx, "", "users"); err != nil {
 		t.Fatalf("Delete() failed: %v", err)
 	}
 	list, _ = srs.List(ctx)
@@ -1583,7 +1583,7 @@ func TestStatefulResourceStore_Create_DuplicateName(t *testing.T) {
 func TestStatefulResourceStore_Delete_NotFound(t *testing.T) {
 	fs := newTestStore(t)
 	ctx := context.Background()
-	err := fs.StatefulResources().Delete(ctx, "nonexistent")
+	err := fs.StatefulResources().Delete(ctx, "", "nonexistent")
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -1597,12 +1597,58 @@ func TestStatefulResourceStore_DeleteAll(t *testing.T) {
 	_ = srs.Create(ctx, &config.StatefulResourceConfig{Name: "users"})
 	_ = srs.Create(ctx, &config.StatefulResourceConfig{Name: "products"})
 
-	if err := srs.DeleteAll(ctx); err != nil {
+	if err := srs.DeleteAll(ctx, ""); err != nil {
 		t.Fatalf("DeleteAll() failed: %v", err)
 	}
 	list, _ := srs.List(ctx)
 	if len(list) != 0 {
 		t.Errorf("expected 0, got %d", len(list))
+	}
+}
+
+// TestStatefulResourceStore_WorkspaceIsolation is a regression test for issue #12.
+// Two workspaces must be able to register resources with the same name, and
+// Delete/DeleteAll must be scoped to one workspace at a time.
+func TestStatefulResourceStore_WorkspaceIsolation(t *testing.T) {
+	fs := newTestStore(t)
+	ctx := context.Background()
+	srs := fs.StatefulResources()
+
+	// Same name, different workspaces — both must succeed.
+	if err := srs.Create(ctx, &config.StatefulResourceConfig{Name: "orders", Workspace: "ws-a"}); err != nil {
+		t.Fatalf("Create ws-a: %v", err)
+	}
+	if err := srs.Create(ctx, &config.StatefulResourceConfig{Name: "orders", Workspace: "ws-b"}); err != nil {
+		t.Fatalf("Create ws-b: %v", err)
+	}
+	// Same (workspace, name) is a duplicate.
+	if err := srs.Create(ctx, &config.StatefulResourceConfig{Name: "orders", Workspace: "ws-a"}); !errors.Is(err, store.ErrAlreadyExists) {
+		t.Errorf("expected ErrAlreadyExists, got %v", err)
+	}
+
+	// Delete only touches the named workspace.
+	if err := srs.Delete(ctx, "ws-a", "orders"); err != nil {
+		t.Fatalf("Delete ws-a: %v", err)
+	}
+	list, _ := srs.List(ctx)
+	if len(list) != 1 || list[0].Workspace != "ws-b" {
+		t.Errorf("expected only ws-b orders to remain, got %+v", list)
+	}
+
+	// DeleteAll is also workspace-scoped.
+	_ = srs.Create(ctx, &config.StatefulResourceConfig{Name: "products", Workspace: "ws-b"})
+	_ = srs.Create(ctx, &config.StatefulResourceConfig{Name: "products", Workspace: "ws-c"})
+	if err := srs.DeleteAll(ctx, "ws-b"); err != nil {
+		t.Fatalf("DeleteAll ws-b: %v", err)
+	}
+	list, _ = srs.List(ctx)
+	for _, r := range list {
+		if r.Workspace == "ws-b" {
+			t.Errorf("ws-b resource %q should have been deleted", r.Name)
+		}
+	}
+	if len(list) != 1 || list[0].Workspace != "ws-c" {
+		t.Errorf("expected only ws-c products to remain, got %+v", list)
 	}
 }
 
@@ -1629,10 +1675,10 @@ func TestStatefulResourceStore_ReadOnly(t *testing.T) {
 	if err := srs.Create(ctx, &config.StatefulResourceConfig{Name: "x"}); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Create: expected ErrReadOnly, got %v", err)
 	}
-	if err := srs.Delete(ctx, "x"); !errors.Is(err, store.ErrReadOnly) {
+	if err := srs.Delete(ctx, "", "x"); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Delete: expected ErrReadOnly, got %v", err)
 	}
-	if err := srs.DeleteAll(ctx); !errors.Is(err, store.ErrReadOnly) {
+	if err := srs.DeleteAll(ctx, ""); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("DeleteAll: expected ErrReadOnly, got %v", err)
 	}
 }
@@ -1668,8 +1714,8 @@ func TestCustomOperationStore_CRUD(t *testing.T) {
 		t.Errorf("expected 1 step, got %d", len(list[0].Steps))
 	}
 
-	// Delete by name
-	if err := cos.Delete(ctx, "TransferFunds"); err != nil {
+	// Delete by (workspace, name)
+	if err := cos.Delete(ctx, "", "TransferFunds"); err != nil {
 		t.Fatalf("Delete() failed: %v", err)
 	}
 	list, _ = cos.List(ctx)
@@ -1693,7 +1739,7 @@ func TestCustomOperationStore_Create_DuplicateName(t *testing.T) {
 func TestCustomOperationStore_Delete_NotFound(t *testing.T) {
 	fs := newTestStore(t)
 	ctx := context.Background()
-	err := fs.CustomOperations().Delete(ctx, "nonexistent")
+	err := fs.CustomOperations().Delete(ctx, "", "nonexistent")
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -1707,7 +1753,7 @@ func TestCustomOperationStore_DeleteAll(t *testing.T) {
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Op1"})
 	_ = cos.Create(ctx, &config.CustomOperationConfig{Name: "Op2"})
 
-	if err := cos.DeleteAll(ctx); err != nil {
+	if err := cos.DeleteAll(ctx, ""); err != nil {
 		t.Fatalf("DeleteAll() failed: %v", err)
 	}
 	list, _ := cos.List(ctx)
@@ -1739,10 +1785,10 @@ func TestCustomOperationStore_ReadOnly(t *testing.T) {
 	if err := cos.Create(ctx, &config.CustomOperationConfig{Name: "x"}); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Create: expected ErrReadOnly, got %v", err)
 	}
-	if err := cos.Delete(ctx, "x"); !errors.Is(err, store.ErrReadOnly) {
+	if err := cos.Delete(ctx, "", "x"); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("Delete: expected ErrReadOnly, got %v", err)
 	}
-	if err := cos.DeleteAll(ctx); !errors.Is(err, store.ErrReadOnly) {
+	if err := cos.DeleteAll(ctx, ""); !errors.Is(err, store.ErrReadOnly) {
 		t.Errorf("DeleteAll: expected ErrReadOnly, got %v", err)
 	}
 }
@@ -1770,9 +1816,16 @@ func TestFileStore_Persistence_RoundTrip(t *testing.T) {
 	_ = fs1.Recordings().Create(ctx, &store.Recording{ID: "rec-persist", Protocol: "http"})
 	_ = fs1.RequestLog().Append(ctx, &store.RequestLogEntry{ID: "log-persist", Method: "GET"})
 	_ = fs1.StatefulResources().Create(ctx, &config.StatefulResourceConfig{Name: "persist-res"})
+	// Same name in a different workspace must round-trip independently (issue #12).
+	_ = fs1.StatefulResources().Create(ctx, &config.StatefulResourceConfig{Name: "persist-res", Workspace: "ws-persist"})
 	_ = fs1.CustomOperations().Create(ctx, &config.CustomOperationConfig{
 		Name:  "persist-op",
 		Steps: []config.CustomStepConfig{{Type: "read", Resource: "users", ID: "input.id", As: "user"}},
+	})
+	_ = fs1.CustomOperations().Create(ctx, &config.CustomOperationConfig{
+		Name:      "persist-op",
+		Workspace: "ws-persist",
+		Steps:     []config.CustomStepConfig{{Type: "read", Resource: "users", ID: "input.id", As: "user"}},
 	})
 	_ = fs1.Preferences().Set(ctx, &store.Preferences{Theme: "dark", DefaultMockPort: 4280})
 	_ = fs1.Close()
@@ -1824,19 +1877,39 @@ func TestFileStore_Persistence_RoundTrip(t *testing.T) {
 		t.Errorf("log method wrong: %q", logEntry.Method)
 	}
 
-	// Stateful resources
+	// Stateful resources — both buckets (default and ws-persist) must round-trip.
 	srs, _ := fs2.StatefulResources().List(ctx)
-	if len(srs) != 1 || srs[0].Name != "persist-res" {
-		t.Errorf("stateful resources not persisted correctly: %+v", srs)
+	if len(srs) != 2 {
+		t.Errorf("expected 2 stateful resources after reload, got %d: %+v", len(srs), srs)
+	}
+	srWorkspaces := map[string]bool{}
+	for _, r := range srs {
+		if r.Name != "persist-res" {
+			t.Errorf("unexpected resource name %q", r.Name)
+		}
+		srWorkspaces[r.Workspace] = true
+	}
+	if !srWorkspaces[""] || !srWorkspaces["ws-persist"] {
+		t.Errorf("expected stateful resources in default and ws-persist workspaces, got %+v", srWorkspaces)
 	}
 
-	// Custom operations
+	// Custom operations — both buckets must round-trip.
 	cos, _ := fs2.CustomOperations().List(ctx)
-	if len(cos) != 1 || cos[0].Name != "persist-op" {
-		t.Errorf("custom operations not persisted correctly: %+v", cos)
+	if len(cos) != 2 {
+		t.Errorf("expected 2 custom operations after reload, got %d: %+v", len(cos), cos)
 	}
-	if len(cos) == 1 && len(cos[0].Steps) != 1 {
-		t.Errorf("custom operation steps not persisted correctly: %+v", cos[0].Steps)
+	coWorkspaces := map[string]bool{}
+	for _, op := range cos {
+		if op.Name != "persist-op" {
+			t.Errorf("unexpected op name %q", op.Name)
+		}
+		if len(op.Steps) != 1 {
+			t.Errorf("custom operation steps not persisted correctly: %+v", op.Steps)
+		}
+		coWorkspaces[op.Workspace] = true
+	}
+	if !coWorkspaces[""] || !coWorkspaces["ws-persist"] {
+		t.Errorf("expected custom operations in default and ws-persist workspaces, got %+v", coWorkspaces)
 	}
 
 	// Preferences

--- a/pkg/store/interfaces.go
+++ b/pkg/store/interfaces.go
@@ -135,27 +135,41 @@ type MockStore interface {
 }
 
 // StatefulResourceStore handles persistence for stateful resource configurations.
+//
+// Identity is (workspaceID, name): two workspaces may each register a resource
+// with the same name. The workspace is taken from each config's Workspace
+// field on Create. An empty workspaceID denotes the default workspace.
 type StatefulResourceStore interface {
-	// List returns all persisted stateful resource configs.
+	// List returns all persisted stateful resource configs across every workspace.
+	// Each entry's Workspace field identifies its bucket.
 	List(ctx context.Context) ([]*config.StatefulResourceConfig, error)
-	// Create persists a new stateful resource config.
+	// Create persists a new stateful resource config. The Workspace field on
+	// res determines its workspace bucket.
 	Create(ctx context.Context, res *config.StatefulResourceConfig) error
-	// Delete removes a stateful resource config by name.
-	Delete(ctx context.Context, name string) error
-	// DeleteAll removes all stateful resource configs.
-	DeleteAll(ctx context.Context) error
+	// Delete removes a stateful resource config from the given workspace by name.
+	Delete(ctx context.Context, workspaceID, name string) error
+	// DeleteAll removes every stateful resource config in the given workspace.
+	// It does NOT touch other workspaces.
+	DeleteAll(ctx context.Context, workspaceID string) error
 }
 
 // CustomOperationStore handles persistence for custom operation definitions.
+//
+// Identity is (workspaceID, name): two workspaces may each register an operation
+// with the same name. The workspace is taken from each config's Workspace
+// field on Create. An empty workspaceID denotes the default workspace.
 type CustomOperationStore interface {
-	// List returns all persisted custom operation configs.
+	// List returns all persisted custom operation configs across every workspace.
+	// Each entry's Workspace field identifies its bucket.
 	List(ctx context.Context) ([]*config.CustomOperationConfig, error)
-	// Create persists a new custom operation config.
+	// Create persists a new custom operation config. The Workspace field on
+	// op determines its workspace bucket.
 	Create(ctx context.Context, op *config.CustomOperationConfig) error
-	// Delete removes a custom operation config by name.
-	Delete(ctx context.Context, name string) error
-	// DeleteAll removes all custom operation configs.
-	DeleteAll(ctx context.Context) error
+	// Delete removes a custom operation config from the given workspace by name.
+	Delete(ctx context.Context, workspaceID, name string) error
+	// DeleteAll removes every custom operation config in the given workspace.
+	// It does NOT touch other workspaces.
+	DeleteAll(ctx context.Context, workspaceID string) error
 }
 
 // FolderFilter provides filtering criteria for folder list operations.


### PR DESCRIPTION
Fixes #12.

## Summary

When importing a config into a named workspace, mocks correctly received the active `workspaceId` but `statefulResources` and `customOperations` were always registered under the default workspace `""`. At request time, `StateStore.Get(mock.WorkspaceID, name)` and `Bridge.GetCustomOperation` looked in the wrong bucket and the request 404'd.

There were two layers to the bug:

1. **Runtime** — `engineclient.Client.ImportConfig` didn't accept or forward a `workspaceID`, so the engine handler always saw an empty `?workspaceId=` query and registered everything under `""`.
2. **Persistence** — the file store treated `(name)` as identity instead of `(workspace, name)`; the admin and engine each held their own `FileStore` pointed at the same `data.json` and raced on save, so the engine's stale view used to overwrite admin's freshly written entries on shutdown; `mockd start` never called `LoadFromStore`, so persisted resources weren't restored on restart.

## What changed

- `Workspace` field added to `CustomOperationConfig` (matching the existing one on `StatefulResourceConfig`); both are documented as persisted parts of the `(workspace, name)` identity.
- Store interfaces: `Delete(ctx, workspaceID, name)` and `DeleteAll(ctx, workspaceID)` for both `StatefulResourceStore` and `CustomOperationStore`. Same name across workspaces is now allowed. `replace=true` scopes to one workspace.
- `engineclient.Client.ImportConfig` accepts a `workspaceID` and appends it as `?workspaceId=`. `pushImportToEngines` threads it through.
- Admin `handleImportConfig` passes the resolved `workspaceID` to the engine and to `persistStatefulResources` / `persistCustomOperations`, which stamp it on each entry before persisting.
- Engine `handleImportConfig` honors a per-entity `Workspace` field with the URL query as fallback default, and dual-writes resources/customOps to its own persistent store so the admin/engine `FileStore` race on `data.json` no longer drops them.
- `config_loader` registers persisted custom operations under their own `Workspace` field instead of `""`.
- `mockd start` now calls `server.LoadFromStore()` so persisted stateful resources and custom operations are restored to the runtime engine after a restart.
- Admin stateful CRUD handlers (`handleAddStateResource`, `handleRegisterCustomOperation`, `handleDeleteStateResource`, `handleDeleteCustomOperation`) stamp and thread the workspaceID through the file store.
- The replace path in `handleImportConfig` also scopes its mock-store cleanup to the target workspace via `MockFilter.WorkspaceID`, so a replace import no longer wipes other workspaces' file-store entries.

## Test plan

- [x] `go test -race ./pkg/...` — all packages pass, zero races
- [x] `go test ./tests/integration/...` — all pass (excluding `TestBinaryE2E_ExportMocks`, which fails identically on `origin/main` and is unrelated)
- [x] New unit tests added and mutation-tested to confirm they catch regressions:
  - `TestStatefulResourceStore_WorkspaceIsolation` and `TestCustomOperationStore_WorkspaceIsolation` cover `(workspace, name)` identity plus scoped `Delete` and `DeleteAll`
  - `TestFileStore_Persistence_RoundTrip` extended to assert resources and operations with the same name in different workspaces both round-trip across save+reload
  - `TestImportConfig_WorkspaceIDInQuery` asserts the engineclient forwards the query parameter when set and omits it when empty
  - `TestHandleImportConfig/forwards_workspaceId_query_parameter_to_engine_on_import_(issue_#12)` covers the admin handler end-to-end
  - `TestHandleImportConfig/replace_import_preserves_other_workspaces'_resources_(issue_#12)` asserts other workspaces' mocks, resources, and custom operations all survive a replace import into a different workspace
- [x] Manual end-to-end against the built binary, replicating the issue's exact reproduction:
  - Single workspace: `mockd workspace create` + `mockd workspace use` + `mockd import` + `POST /orders` → `201` (was `404` on `main`)
  - Same flow plus `mockd stop` and `mockd start` → `POST /orders` → `201` after restart, with the previously created stateful item still present
  - Two workspaces with the same `orders` table name → independent buckets, both reload after restart with `[('orders', 'ws_a'), ('orders', 'ws_b')]` in the persisted `data.json`
  - `mockd import --replace` into one workspace leaves the other workspace's persisted resources, custom operations, and mocks untouched in the file store

## Out of scope / known limitation

The engine's runtime `ClearMocks()` is workspace-unscoped: a `replace=true` import wipes other workspaces' mocks from the engine's in-memory state until the next restart (the admin file store correctly preserves them, so a restart restores them). Issue #12 explicitly notes that mocks already get the correct `workspaceId`; this only affects the runtime `replace` path for mocks and is best handled in a follow-up PR.