### PR TITLE
docs: restructure README comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Every other mock tool makes you choose: pick one protocol, install a runtime, bo
 | REST / HTTP | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | gRPC | ✅ | 🔌 Ext | ❌ | ❌ | ❌ | ✅ | ❌ |
 | GraphQL | ✅ | 🔌 Ext | ❌ | ❌ | ❌ | ✅ | ❌ |
-| WebSocket | ✅ | 🔌 Ext (beta) | ✅ | ❌ | ❌ | ⚠️ unverified | ❌ |
+| WebSocket | ✅ | 🔌 Ext (beta) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | MQTT | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | SSE | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | SOAP (WSDL) | ✅ | ❌ | Partial | ❌ | Partial | ✅ | ❌ |
@@ -109,7 +109,7 @@ Every other mock tool makes you choose: pick one protocol, install a runtime, bo
 | Fault injection (delay, errors) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
 | Chaos profiles | ✅ | ⚠️ Cloud | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Circuit breakers | ✅ | ⚠️ Cloud | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Bandwidth throttling | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Bandwidth throttling | ✅ | ❌ | ❌ | ❌ | ❌ | roadmap | ❌ |
 | Admin REST API | ✅ | ✅ | CLI only | ❌ | ✅ | ✅ | Partial |
 | Built-in web dashboard | ✅ | ⚠️ Cloud | ⚠️ Cloud | ❌ | ✅ read-only | ✅ | ❌ |
 | Native desktop GUI | ❌ | ❌ | ✅ Electron | ❌ | ❌ | ❌ | ❌ |
@@ -121,7 +121,7 @@ Every other mock tool makes you choose: pick one protocol, install a runtime, bo
 | | mockd | WireMock OSS | Mockoon | Prism | MockServer | Beeceptor | json-server |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | OpenAPI import | ✅ | ⚠️ Cloud | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Postman import | ✅ | ⚠️ Cloud | ❌ | ✅ | ❌ | ⚠️ unverified | ❌ |
+| Postman import | ✅ | ⚠️ Cloud | ❌ | ✅ | ❌ | ❌ | ❌ |
 | HAR import | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | WSDL import | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | cURL import | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -141,7 +141,7 @@ Every other mock tool makes you choose: pick one protocol, install a runtime, bo
 | Beeceptor free tier | 50 / day / endpoint | 3 | $10/mo+ for more |
 | json-server | unlimited | unlimited | free (MIT) |
 
-**Legend**: ✅ built-in • 🔌 Ext = separate OSS extension • ⚠️ Cloud = only in paid / hosted tier • Partial = limited implementation • ⚠️ unverified = claim present but not yet confirmed against primary docs
+**Legend**: ✅ built-in • 🔌 Ext = separate OSS extension • ⚠️ Cloud = only in paid / hosted tier • Partial = limited implementation • roadmap = on the project's stated roadmap, not yet shipped
 
 > **Note on WireMock imports.** The `⚠️ Cloud` marks on OpenAPI and Postman import reflect first-party WireMock features. Community converters exist (e.g. `openapi-to-wiremock`, OpenAPI Generator targets) but are not bundled with the OSS standalone JAR.
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,88 @@ Pre-built binaries for Linux, macOS, and Windows on the [Releases](https://githu
 
 Every other mock tool makes you choose: pick one protocol, install a runtime, bolt on extensions. mockd doesn't.
 
-| | mockd | WireMock | Mockoon | json-server | Prism | MockServer |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Single binary, no runtime** | :white_check_mark: | :x: JVM | :x: Node | :x: Node | :x: Node | :x: JVM |
-| **HTTP + gRPC + GraphQL + WS** | :white_check_mark: | 🔌 Ext | :x: | :x: | :x: | Partial |
-| **MQTT + SSE + SOAP + OAuth** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-| **Stateful CRUD** | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: | :x: |
-| **Import OpenAPI/Postman/HAR** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: |
-| **Chaos engineering** | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: |
-| **MCP server (AI-native)** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-| **Cloud tunnel sharing** | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: |
-| **Built-in web dashboard** | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: |
+| | mockd | WireMock | Mockoon | Prism | MockServer | Beeceptor | json-server |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Single binary, no runtime** | ✅ | ❌ JVM | ❌ Electron | ✅ | ❌ JVM | ❌ SaaS | ❌ Node |
+| **All 9 protocols built-in** | ✅ | 🔌 Ext | Partial | HTTP only | HTTP only | Partial | REST only |
+| **Chaos profiles + circuit breakers** | ✅ | ⚠️ Cloud | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **MCP server** | ✅ local | ⚠️ Cloud | ❌ | ❌ | ❌ | ⚠️ Cloud, Team+ | ❌ |
+| **Free + self-hostable, unlimited** | ✅ | ✅ | ✅ | ✅ | ✅ | 50 req/day | ✅ |
 
-> 🔌 **Ext** = available via separate extension, not bundled. mockd includes everything in a single binary.
+> 🔌 **Ext** = requires separate extension JAR • ⚠️ **Cloud** = only in paid/hosted tier
+
+<details>
+<summary><strong>Full capability matrix</strong> (deployment, protocols, capabilities, imports/exports, pricing)</summary>
+
+### Deployment
+
+| | mockd | WireMock | Mockoon | Prism | MockServer | Beeceptor | json-server |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Native single binary | ✅ Go | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Runtime required | none | JVM | Electron/Node | optional Node | JVM | n/a (SaaS) | Node |
+| Docker image | ✅ | ✅ | ✅ CLI | ✅ | ✅ | ⚠️ Enterprise | ❌ |
+| Managed SaaS offering | roadmap | WireMock Cloud | Mockoon Cloud | Stoplight | ❌ | ✅ | ❌ |
+
+### Protocol support
+
+| | mockd | WireMock OSS | Mockoon | Prism | MockServer | Beeceptor | json-server |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| REST / HTTP | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| gRPC | ✅ | 🔌 Ext | ❌ | ❌ | ❌ | ✅ | ❌ |
+| GraphQL | ✅ | 🔌 Ext | ❌ | ❌ | ❌ | ✅ | ❌ |
+| WebSocket | ✅ | 🔌 Ext (beta) | ✅ | ❌ | ❌ | ⚠️ unverified | ❌ |
+| MQTT | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| SSE | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| SOAP (WSDL) | ✅ | ❌ | Partial | ❌ | Partial | ✅ | ❌ |
+| mTLS | ✅ | ✅ | Partial | ❌ | ✅ | ✅ | ❌ |
+| OAuth flows | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+### Capabilities
+
+| | mockd | WireMock OSS | Mockoon | Prism | MockServer | Beeceptor | json-server |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Stateful CRUD | ✅ | ❌ | ✅ | Partial | ❌ | ✅ | ✅ |
+| Multi-step stateful flows | ✅ | ✅ Scenarios | Partial | ❌ | Partial | ✅ | ❌ |
+| Fault injection (delay, errors) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Chaos profiles | ✅ | ⚠️ Cloud | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Circuit breakers | ✅ | ⚠️ Cloud | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Bandwidth throttling | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Admin REST API | ✅ | ✅ | CLI only | ❌ | ✅ | ✅ | Partial |
+| Built-in web dashboard | ✅ | ⚠️ Cloud | ⚠️ Cloud | ❌ | ✅ read-only | ✅ | ❌ |
+| Native desktop GUI | ❌ | ❌ | ✅ Electron | ❌ | ❌ | ❌ | ❌ |
+| MCP server | ✅ local | ⚠️ Cloud | ❌ | ❌ | ❌ | ⚠️ Cloud Team+ | ❌ |
+| Cloud tunnel sharing | ✅ | ❌ | ⚠️ Cloud | ❌ | ❌ | ✅ | ❌ |
+
+### Import / export
+
+| | mockd | WireMock OSS | Mockoon | Prism | MockServer | Beeceptor | json-server |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| OpenAPI import | ✅ | ⚠️ Cloud | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Postman import | ✅ | ⚠️ Cloud | ❌ | ✅ | ❌ | ⚠️ unverified | ❌ |
+| HAR import | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| WSDL import | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| cURL import | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| WireMock format import | ✅ | native | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Mockoon format import | ✅ | ❌ | native | ❌ | ❌ | ❌ | ❌ |
+| HAR export | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
+
+### Free tier limits
+
+| | Requests | Mock rules | Cost |
+|---|---|---|---|
+| mockd | unlimited | unlimited | free (Apache 2.0) |
+| WireMock OSS | unlimited | unlimited | free (Apache 2.0) |
+| Mockoon desktop / CLI | unlimited | unlimited | free (MIT) |
+| Prism | unlimited | unlimited | free (Apache 2.0) |
+| MockServer | unlimited | unlimited | free (Apache 2.0) |
+| Beeceptor free tier | 50 / day / endpoint | 3 | $10/mo+ for more |
+| json-server | unlimited | unlimited | free (MIT) |
+
+**Legend**: ✅ built-in • 🔌 Ext = separate OSS extension • ⚠️ Cloud = only in paid / hosted tier • Partial = limited implementation • ⚠️ unverified = claim present but not yet confirmed against primary docs
+
+> **Note on WireMock imports.** The `⚠️ Cloud` marks on OpenAPI and Postman import reflect first-party WireMock features. Community converters exist (e.g. `openapi-to-wiremock`, OpenAPI Generator targets) but are not bundled with the OSS standalone JAR.
+
+</details>
 
 ## Digital Twins
 


### PR DESCRIPTION
## Summary

Restructures the README comparison table into a compact "at a glance" section (5 differentiators) plus an expandable full matrix covering Deployment, Protocol support, Capabilities, Import/export, and Free tier.

Supersedes #17. Credits @ankitjaininfo's contribution; his feedback on row splits (per-protocol breakout, chaos split, stateful split, separate export row, self-hosted row) is incorporated directly.

## Why restructure rather than row-add

The previous table bundled categories that were doing different work per tool:
- "HTTP + gRPC + GraphQL + WS" obscured WireMock's extension story and MockServer's gRPC gap.
- "Chaos engineering" conflated fault-injection primitives (delay, errors) with chaos-engineering features (named profiles, circuit breakers, bandwidth throttling).
- "Import OpenAPI/Postman/HAR" collapsed three separate formats into one, hiding per-tool differences.
- OSS vs Cloud tier gating (big deal for WireMock and Beeceptor) wasn't visible at all.

Breaking the rows up makes every tool score honestly on what it actually ships, and keeps the table durable as new tools and tiers get added.

## Per-cell sources

Every non-mockd cell was verified against primary-source docs. Two Beeceptor cells originally marked `⚠️ unverified` were resolved by @ankitjaininfo's confirmations on this PR; see commit history.

### mockd

All nine ✅ marks verified against the current codebase at `bfd88c1`:
- Single binary: `go.mod` (Go 1.26.2, no runtime deps)
- Protocols: `pkg/grpc/server.go`, `pkg/graphql/handler.go`, `pkg/websocket/handler.go`, `pkg/mqtt/broker.go`, `pkg/sse/sse.go`, `pkg/soap/handler.go`, `pkg/oauth/handler.go`
- Stateful CRUD: `pkg/stateful/bridge.go`, `pkg/store/file/stateful_resource_store.go`
- Chaos profiles: `pkg/chaos/profiles.go` (10 named profiles)
- Circuit breakers: `pkg/chaos/circuit_breaker.go`
- MCP server: `pkg/mcp/` (18 tools in `tool_defs.go`)
- Imports: `pkg/portability/{openapi,postman,har,wsdl,wiremock,curl,mockoon}.go`
- Tunnel: `pkg/tunnel/manager.go`
- Dashboard: `pkg/admin/dashboard.go` (build-tag gated, included in release binaries)

### WireMock OSS

- Runtime: https://wiremock.org/docs/running-standalone/ (JVM required)
- gRPC / GraphQL / WS as extensions: https://wiremock.org/docs/grpc/, https://wiremock.org/docs/graphql/
- Scenarios (multi-step, no auto-CRUD): https://wiremock.org/docs/stateful-behaviour/
- Fault enum (`EMPTY_RESPONSE`, `CONNECTION_RESET_BY_PEER`, etc.): https://wiremock.org/docs/simulating-faults/
- Chaos modes / circuit breakers are WireMock Cloud features: https://docs.wiremock.io/chaos, https://www.wiremock.io/use-case/chaos-engineering
- OpenAPI / Postman import are Cloud features: https://docs.wiremock.io/openAPI/swagger
- MCP is Cloud-gated: https://www.wiremock.io/mcp-server
- Community converters for OpenAPI exist (e.g. OpenAPI Generator's WireMock target) but are not bundled in the OSS JAR.

### Mockoon

- Desktop Electron app + CLI + Docker: https://mockoon.com/, https://mockoon.com/cli/
- Protocols (REST + WebSocket): https://mockoon.com/features/
- SOAP limited to `application/soap+xml` content type, no WSDL mocking
- mTLS client cert auth on roadmap (issue #1600, Nov 2024), not shipped
- Stateful CRUD via data buckets: https://mockoon.com/docs/latest/api-endpoints/crud-routes/
- Only OpenAPI v2/v3 imports (no Postman, HAR, WSDL): https://mockoon.com/docs/latest/openapi/import-export-openapi-format/
- Web app gated behind Mockoon Cloud paid plans: https://mockoon.com/cloud/
- Pricing: https://mockoon.com/pricing/

### Prism

- Latest release v5.15.9 (2026-04-17) with standalone binaries: https://github.com/stoplightio/prism/releases/latest
  - Assets confirmed via GitHub API: `prism-cli-linux` (116 MB), `prism-cli-macos` (113 MB), `prism-cli-win.exe` (136 MB)
- Also available as Docker image and npm: https://hub.docker.com/r/stoplight/prism
- HTTP/OpenAPI only; no other protocol support: https://stoplight.io/open-source/prism
- Chaos feature request never implemented: https://github.com/stoplightio/prism/discussions/471
- Post-SmartBear deprecation signals (Stoplight Platform → SwaggerHub): https://community.smartbear.com/discussions/stoplight/is-stoplight-dead-after-smartbears-acquisition/263623

### MockServer

- JVM-based, Docker, Helm, Maven, npm wrapper: https://www.mock-server.com/mock_server/running_mock_server.html
- Homepage lists only HTTP, HTTPS/TLS, SOCKS as supported protocols: https://www.mock-server.com/
- No native gRPC, GraphQL, WebSocket endpoint mocking, MQTT, or SSE (verified absent from docs)
- Fault injection (delay, `dropConnection`, `randomBytes`): https://www.mock-server.com/mock_server/creating_expectations.html
- OpenAPI import: https://www.mock-server.com/mock_server/using_openapi.html
- Read-only dashboard: https://www.mock-server.com/mock_server/mockserver_ui.html
- Latest v5.15.0, low activity

### Beeceptor

- Pricing and tier gating (on-prem is Enterprise-only per the pricing page): https://beeceptor.com/pricing/
- Protocols (REST, GraphQL via SDL, gRPC via proto, SOAP via WSDL, mTLS): https://beeceptor.com/docs/protocols-supported/
- Stateful (data-store + lists + step counters + CRUD routes capped at 10 on free tier): https://beeceptor.com/docs/tutorials/building-multi-step-user-journeys-using-api-mocking/
- OpenAPI import: https://beeceptor.com/openapi-mock-server/
- Fault injection (delay, status codes, malformed responses, weighted responses): https://beeceptor.com/docs/articles/api-virtualization-chaos-engineering/, https://beeceptor.com/docs/create-mocking-server/#weighted-response
- MCP endpoint gated behind Team plan: https://beeceptor.com/docs/mcp-agentic-mode/
- Own tunnel CLI (not ngrok): https://beeceptor.com/docs/local-tunneling-by-exposing-service-port/
- FAQ on on-prem: https://beeceptor.com/faq/ ("Contact support for details")
- No public Docker image on Docker Hub; GitHub org (https://github.com/beeceptor) has no installer or Helm chart

**Beeceptor row resolution (per @ankitjaininfo confirmations):**
- WebSocket: ❌ (mocking not supported, only HTTP proxy)
- Postman import: ❌ (not available)
- Bandwidth throttling: marked `roadmap` (2026 roadmap item)
- OAuth flows: stays ❌ (hosted oauth-mock is a template, not native OAuth flow infrastructure)
- Chaos profiles: stays ❌ (weighted responses are credited under Fault injection; this row is for named pre-built profiles like `mobile-3g`, `dns-flaky`)

### json-server

- Latest `v1.0.0-beta.15` (2026-03-23), still in beta, feature-frozen: https://github.com/typicode/json-server/releases/tag/v1.0.0-beta.15
- REST-only, Node-only (no Docker, no binary): https://github.com/typicode/json-server#install
- `--delay` flag removed in v1, no fault injection: https://github.com/typicode/json-server#migration-notes-v0--v1
- Auto-CRUD from `db.json` is the flagship feature: https://github.com/typicode/json-server#routes

## Test plan

- [ ] Render README.md on GitHub and visually inspect at-a-glance table on desktop and mobile
- [ ] Expand `<details>` block and verify all four sub-tables render correctly
- [ ] Confirm emoji + unicode characters render consistently (no `:white_check_mark:` leftovers)
- [ ] Verify no links in the comparison section are broken
- [x] @ankitjaininfo confirmations applied (WebSocket, Postman, Bandwidth throttling); editorial calls held on OAuth and Chaos profiles with rationale in commit history