### PR TITLE
fix(graphql): __typename returns actual schema type name on nested objects

### DIFF
--- a/pkg/graphql/executor.go
+++ b/pkg/graphql/executor.go
@@ -708,7 +708,7 @@ func (e *Executor) executeSelectionSetWithDoc(ctx context.Context, doc *ast.Quer
 				// Prune the response to only include selected sub-fields
 				// This ensures @skip/@include on sub-fields work correctly
 				if s.SelectionSet != nil {
-					value = e.pruneResponse(doc, value, s.SelectionSet, variables)
+					value = e.pruneResponse(doc, e.fieldTypeName(opType, s.Name), value, s.SelectionSet, variables)
 				}
 				result[alias] = value
 			}
@@ -755,7 +755,7 @@ func (e *Executor) executeSelectionSetWithDoc(ctx context.Context, doc *ast.Quer
 // respecting @skip/@include directives. This is necessary because mock resolvers return
 // complete pre-configured response objects, and directive-based field exclusion needs to
 // happen as a post-processing step.
-func (e *Executor) pruneResponse(doc *ast.QueryDocument, value interface{}, selections ast.SelectionSet, variables map[string]interface{}) interface{} {
+func (e *Executor) pruneResponse(doc *ast.QueryDocument, typeName string, value interface{}, selections ast.SelectionSet, variables map[string]interface{}) interface{} {
 	if value == nil || selections == nil {
 		return value
 	}
@@ -764,14 +764,14 @@ func (e *Executor) pruneResponse(doc *ast.QueryDocument, value interface{}, sele
 	case map[string]interface{}:
 		// Collect all requested field names (expanding fragments)
 		result := make(map[string]interface{})
-		e.collectSelectedFields(doc, result, v, selections, variables)
+		e.collectSelectedFields(doc, typeName, result, v, selections, variables)
 		return result
 
 	case []interface{}:
 		// Apply pruning to each element in the array
 		pruned := make([]interface{}, len(v))
 		for i, item := range v {
-			pruned[i] = e.pruneResponse(doc, item, selections, variables)
+			pruned[i] = e.pruneResponse(doc, typeName, item, selections, variables)
 		}
 		return pruned
 
@@ -782,7 +782,7 @@ func (e *Executor) pruneResponse(doc *ast.QueryDocument, value interface{}, sele
 
 // collectSelectedFields walks the selection set and copies matching fields from src to dst,
 // respecting @skip/@include directives and expanding fragments.
-func (e *Executor) collectSelectedFields(doc *ast.QueryDocument, dst, src map[string]interface{}, selections ast.SelectionSet, variables map[string]interface{}) {
+func (e *Executor) collectSelectedFields(doc *ast.QueryDocument, typeName string, dst, src map[string]interface{}, selections ast.SelectionSet, variables map[string]interface{}) {
 	for _, sel := range selections {
 		switch s := sel.(type) {
 		case *ast.Field:
@@ -794,12 +794,19 @@ func (e *Executor) collectSelectedFields(doc *ast.QueryDocument, dst, src map[st
 				alias = s.Name
 			}
 			if s.Name == "__typename" {
-				dst[alias] = "Object"
+				// Resolve the actual schema-defined type name for this object.
+				// Fall back to "Object" only when the type is unknown (e.g. no
+				// schema type information is available for this selection).
+				if typeName != "" {
+					dst[alias] = typeName
+				} else {
+					dst[alias] = "Object"
+				}
 				continue
 			}
 			if val, ok := src[s.Name]; ok {
 				if s.SelectionSet != nil {
-					val = e.pruneResponse(doc, val, s.SelectionSet, variables)
+					val = e.pruneResponse(doc, e.fieldTypeName(typeName, s.Name), val, s.SelectionSet, variables)
 				}
 				dst[alias] = val
 			}
@@ -811,7 +818,13 @@ func (e *Executor) collectSelectedFields(doc *ast.QueryDocument, dst, src map[st
 			if doc != nil {
 				for _, frag := range doc.Fragments {
 					if frag.Name == s.Name {
-						e.collectSelectedFields(doc, dst, src, frag.SelectionSet, variables)
+						// A fragment's type condition narrows the concrete type, so
+						// prefer it when resolving __typename inside the fragment.
+						fragType := typeName
+						if frag.TypeCondition != "" {
+							fragType = frag.TypeCondition
+						}
+						e.collectSelectedFields(doc, fragType, dst, src, frag.SelectionSet, variables)
 						break
 					}
 				}
@@ -821,9 +834,29 @@ func (e *Executor) collectSelectedFields(doc *ast.QueryDocument, dst, src map[st
 			if e.shouldSkipField(s.Directives, variables) {
 				continue
 			}
-			e.collectSelectedFields(doc, dst, src, s.SelectionSet, variables)
+			// An inline fragment's type condition narrows the concrete type.
+			fragType := typeName
+			if s.TypeCondition != "" {
+				fragType = s.TypeCondition
+			}
+			e.collectSelectedFields(doc, fragType, dst, src, s.SelectionSet, variables)
 		}
 	}
+}
+
+// fieldTypeName returns the unwrapped (named) GraphQL type of the field
+// fieldName declared on the type typeName, or "" when it cannot be resolved
+// from the schema. Non-null and list wrappers are stripped so the result is
+// always a concrete type name suitable for __typename resolution.
+func (e *Executor) fieldTypeName(typeName, fieldName string) string {
+	if e.schema == nil || typeName == "" {
+		return ""
+	}
+	field := e.schema.GetField(typeName, fieldName)
+	if field == nil || field.Type == nil {
+		return ""
+	}
+	return field.Type.Name()
 }
 
 // shouldSkipField evaluates @skip(if:) and @include(if:) directives.

--- a/pkg/graphql/executor_test.go
+++ b/pkg/graphql/executor_test.go
@@ -592,6 +592,121 @@ func TestExecutor_Execute_TypenameField(t *testing.T) {
 	}
 }
 
+// nestedTypenameSchema exercises __typename resolution on nested object types,
+// object types reached via lists, and aliases.
+const nestedTypenameSchema = `
+type Query {
+	user(id: ID!): User
+	users: [User!]!
+}
+
+type User {
+	id: ID!
+	name: String!
+	profile: Profile
+}
+
+type Profile {
+	bio: String
+}
+`
+
+func TestExecutor_Execute_NestedTypename(t *testing.T) {
+	schema, err := ParseSchema(nestedTypenameSchema)
+	if err != nil {
+		t.Fatalf("ParseSchema() error = %v", err)
+	}
+
+	config := &GraphQLConfig{
+		Resolvers: map[string]ResolverConfig{
+			"Query.user": {
+				Response: map[string]interface{}{
+					"id":   "1",
+					"name": "Alice",
+					"profile": map[string]interface{}{
+						"bio": "Hello",
+					},
+				},
+			},
+			"Query.users": {
+				Response: []interface{}{
+					map[string]interface{}{"id": "1", "name": "Alice"},
+					map[string]interface{}{"id": "2", "name": "Bob"},
+				},
+			},
+		},
+	}
+
+	executor := NewExecutor(schema, config)
+
+	t.Run("nested object returns schema type name", func(t *testing.T) {
+		req := &GraphQLRequest{
+			Query: `query { user(id: "1") { __typename id } }`,
+		}
+		resp := executor.Execute(context.Background(), req)
+		if len(resp.Errors) > 0 {
+			t.Fatalf("Execute() returned errors: %v", resp.Errors)
+		}
+		data := resp.Data.(map[string]interface{})
+		user := data["user"].(map[string]interface{})
+		if user["__typename"] != "User" {
+			t.Errorf("user.__typename = %v, want 'User'", user["__typename"])
+		}
+	})
+
+	t.Run("doubly-nested object returns schema type name", func(t *testing.T) {
+		req := &GraphQLRequest{
+			Query: `query { user(id: "1") { profile { __typename bio } } }`,
+		}
+		resp := executor.Execute(context.Background(), req)
+		if len(resp.Errors) > 0 {
+			t.Fatalf("Execute() returned errors: %v", resp.Errors)
+		}
+		data := resp.Data.(map[string]interface{})
+		user := data["user"].(map[string]interface{})
+		profile := user["profile"].(map[string]interface{})
+		if profile["__typename"] != "Profile" {
+			t.Errorf("profile.__typename = %v, want 'Profile'", profile["__typename"])
+		}
+	})
+
+	t.Run("__typename via alias on nested object", func(t *testing.T) {
+		req := &GraphQLRequest{
+			Query: `query { user(id: "1") { kind: __typename } }`,
+		}
+		resp := executor.Execute(context.Background(), req)
+		if len(resp.Errors) > 0 {
+			t.Fatalf("Execute() returned errors: %v", resp.Errors)
+		}
+		data := resp.Data.(map[string]interface{})
+		user := data["user"].(map[string]interface{})
+		if user["kind"] != "User" {
+			t.Errorf("user.kind (aliased __typename) = %v, want 'User'", user["kind"])
+		}
+	})
+
+	t.Run("list element objects return schema type name", func(t *testing.T) {
+		req := &GraphQLRequest{
+			Query: `query { users { __typename id } }`,
+		}
+		resp := executor.Execute(context.Background(), req)
+		if len(resp.Errors) > 0 {
+			t.Fatalf("Execute() returned errors: %v", resp.Errors)
+		}
+		data := resp.Data.(map[string]interface{})
+		users := data["users"].([]interface{})
+		if len(users) != 2 {
+			t.Fatalf("len(users) = %d, want 2", len(users))
+		}
+		for i, u := range users {
+			um := u.(map[string]interface{})
+			if um["__typename"] != "User" {
+				t.Errorf("users[%d].__typename = %v, want 'User'", i, um["__typename"])
+			}
+		}
+	})
+}
+
 func TestExecutor_Execute_FieldAlias(t *testing.T) {
 	schema, err := ParseSchema(executorTestSchema)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #32. GraphQL `__typename` on a nested object (or an object reached through a list) returned the hardcoded literal string `"Object"` instead of the actual type name defined in the schema (e.g. `User`, `Profile`).

## Root cause

`Executor.collectSelectedFields` in `pkg/graphql/executor.go` populated `__typename` with a hardcoded `"Object"`:

```go
if s.Name == "__typename" {
    dst[alias] = "Object"
    continue
}
```

This function (reached via `pruneResponse` when a field has a sub-selection) had no knowledge of the GraphQL type of the object being pruned, so it could not return the correct name. The top-level `__typename` was already correct (it used the operation type `Query`/`Mutation`); only nested objects were wrong.

## Fix

- Thread the concrete type name through `pruneResponse` and `collectSelectedFields`.
- Add a `fieldTypeName(typeName, fieldName)` helper that resolves a field's return type from the schema, stripping non-null/list wrappers via `ast.Type.Name()`.
- Honor inline and named fragment type conditions so `__typename` inside a fragment reflects the narrowed type.
- Keep the `"Object"` fallback only when no schema type information is available.

## Tests

Added `TestExecutor_Execute_NestedTypename` covering nested objects, doubly-nested objects, aliased `__typename`, and list-element objects. Verified fail-before (returns `Object`) / pass-after. `go build ./...`, `go vet ./pkg/graphql/...`, `go test ./pkg/graphql/...`, and GraphQL integration tests all pass.