### PR TITLE
fix(install): fail loudly on missing/invalid release assets (Fixes #34)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,10 @@ INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 BINARY_NAME="mockd"
 TELEMETRY_URL="https://api.mockd.io/api/telemetry/install"
 
+# Base URLs. Overridable for testing; default to GitHub.
+GITHUB_DOWNLOAD_BASE="${MOCKD_DOWNLOAD_BASE:-https://github.com/${REPO}/releases/download}"
+GITHUB_API_BASE="${MOCKD_API_BASE:-https://api.github.com/repos/${REPO}}"
+
 # Colors (if terminal supports it)
 if [ -t 1 ]; then
     RED='\033[0;31m'
@@ -60,23 +64,54 @@ detect_arch() {
 # Get latest version from GitHub
 get_latest_version() {
     if command -v curl >/dev/null 2>&1; then
-        curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/'
+        curl -fsSL "${GITHUB_API_BASE}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/'
     elif command -v wget >/dev/null 2>&1; then
-        wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/'
+        wget -qO- "${GITHUB_API_BASE}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/'
     else
         error "Neither curl nor wget found. Please install one of them."
     fi
 }
 
-# Download file
+# Download a file to a destination. Returns non-zero (and leaves no body behind)
+# on HTTP errors such as 404/5xx. Without --fail, curl writes the server's error
+# page (e.g. "Not Found") to the destination and still exits 0, which then gets
+# mis-parsed downstream as a checksum/binary — see
+# https://github.com/getmockd/mockd/issues/34
 download() {
     url="$1"
     dest="$2"
     if command -v curl >/dev/null 2>&1; then
-        curl -sSL -o "$dest" "$url"
+        # --fail: exit non-zero on HTTP >= 400 without emitting the error body.
+        curl -fsSL -o "$dest" "$url"
     elif command -v wget >/dev/null 2>&1; then
-        wget -qO "$dest" "$url"
+        # wget exits non-zero on 404, but -O still creates/truncates the file;
+        # remove the stale destination on failure so callers never see a body.
+        wget -qO "$dest" "$url" || { rm -f "$dest"; return 1; }
+    else
+        return 1
     fi
+}
+
+# A valid sha256 hex digest is exactly 64 lowercase hex characters.
+is_sha256() {
+    case "$1" in
+        "" | *[!0-9a-f]*) return 1 ;;
+        *) [ "${#1}" -eq 64 ] ;;
+    esac
+}
+
+# Download and parse the expected checksum for the binary. Fails loudly with an
+# actionable message rather than letting a missing/garbage checksum slip through
+# and surface as a confusing "Expected: Not" comparison failure.
+fetch_expected_checksum() {
+    if ! download "$CHECKSUM_URL" "${TMPDIR}/checksum"; then
+        error "Could not download checksum from ${CHECKSUM_URL}\n  The release asset may be missing or still publishing. Try again shortly, or pin a known-good version with VERSION=<tag>."
+    fi
+    expected=$(awk '{print $1}' "${TMPDIR}/checksum")
+    if ! is_sha256 "$expected"; then
+        error "Downloaded checksum is not a valid sha256 digest (got: '${expected}')\n  The release asset may be corrupt or missing. Try again shortly, or pin a known-good version with VERSION=<tag>."
+    fi
+    printf '%s' "$expected"
 }
 
 main() {
@@ -107,7 +142,7 @@ main() {
     if [ "$OS" = "windows" ]; then
         FILENAME="${FILENAME}.exe"
     fi
-    URL="https://github.com/${REPO}/releases/download/${VERSION}/${FILENAME}"
+    URL="${GITHUB_DOWNLOAD_BASE}/${VERSION}/${FILENAME}"
     CHECKSUM_URL="${URL}.sha256"
 
     # Download binary
@@ -115,13 +150,16 @@ main() {
     trap 'rm -rf "$TMPDIR"' EXIT
 
     info "Downloading ${URL}..."
-    download "$URL" "${TMPDIR}/${BINARY_NAME}"
+    if ! download "$URL" "${TMPDIR}/${BINARY_NAME}"; then
+        error "Could not download ${URL}\n  The release asset may be missing or still publishing. Check that ${VERSION} exists for ${OS}/${ARCH}, try again shortly, or pin a version with VERSION=<tag>."
+    fi
 
-    # Verify checksum if sha256sum is available
+    # Verify checksum if a sha256 tool is available. A missing or malformed
+    # checksum is treated as a hard error (not silently skipped), since it most
+    # likely means the binary download itself is bad.
     if command -v sha256sum >/dev/null 2>&1; then
         info "Verifying checksum..."
-        download "$CHECKSUM_URL" "${TMPDIR}/checksum"
-        EXPECTED=$(awk '{print $1}' "${TMPDIR}/checksum")
+        EXPECTED=$(fetch_expected_checksum)
         ACTUAL=$(sha256sum "${TMPDIR}/${BINARY_NAME}" | awk '{print $1}')
         if [ "$EXPECTED" != "$ACTUAL" ]; then
             error "Checksum verification failed!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"
@@ -129,8 +167,7 @@ main() {
         success "Checksum verified"
     elif command -v shasum >/dev/null 2>&1; then
         info "Verifying checksum..."
-        download "$CHECKSUM_URL" "${TMPDIR}/checksum"
-        EXPECTED=$(awk '{print $1}' "${TMPDIR}/checksum")
+        EXPECTED=$(fetch_expected_checksum)
         ACTUAL=$(shasum -a 256 "${TMPDIR}/${BINARY_NAME}" | awk '{print $1}')
         if [ "$EXPECTED" != "$ACTUAL" ]; then
             error "Checksum verification failed!\n  Expected: ${EXPECTED}\n  Got:      ${ACTUAL}"

--- a/tests/e2e/install_script_test.go
+++ b/tests/e2e/install_script_test.go
@@ -1,0 +1,211 @@
+package e2e_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestInstallScript exercises install.sh end-to-end against a local server that
+// stands in for GitHub releases. It is a regression guard for issue #34, where a
+// 404 on the checksum sidecar caused curl (without --fail) to write the body
+// "Not Found" into the checksum file, which the script then parsed as the
+// expected checksum — producing the confusing "Expected: Not" failure and, worse,
+// could install a non-binary error page when checksum tooling was absent.
+func TestInstallScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is a POSIX shell script; not run on Windows")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	scriptPath := repoFile(t, "install.sh")
+
+	// Map the script's GOOS->os and GOARCH->arch naming.
+	osName := runtime.GOOS // "linux" or "darwin" — matches detect_os output
+	archName := runtime.GOARCH
+	switch archName {
+	case "amd64", "arm64":
+		// already matches detect_arch output
+	default:
+		t.Skipf("unsupported test arch %q", archName)
+	}
+
+	const version = "v9.9.9"
+	binaryName := "mockd-" + osName + "-" + archName
+	fakeBinary := []byte("#!/bin/sh\necho mockd version " + version + "\n")
+	sum := sha256.Sum256(fakeBinary)
+	checksumLine := hex.EncodeToString(sum[:]) + "  " + binaryName + "\n"
+
+	t.Run("happy path installs and verifies checksum", func(t *testing.T) {
+		srv := newReleaseServer(t, releaseConfig{
+			version:      version,
+			binaryName:   binaryName,
+			binary:       fakeBinary,
+			checksumBody: checksumLine,
+			checksum404:  false,
+		})
+		defer srv.Close()
+
+		installDir := t.TempDir()
+		out, err := runInstall(t, scriptPath, srv.URL, version, installDir)
+		if err != nil {
+			t.Fatalf("install.sh failed unexpectedly: %v\noutput:\n%s", err, out)
+		}
+		if !strings.Contains(out, "Checksum verified") {
+			t.Errorf("expected checksum to be verified, output:\n%s", out)
+		}
+		installed := filepath.Join(installDir, "mockd")
+		if data, rerr := os.ReadFile(installed); rerr != nil {
+			t.Fatalf("binary not installed: %v", rerr)
+		} else if string(data) != string(fakeBinary) {
+			t.Errorf("installed binary content mismatch")
+		}
+	})
+
+	// Core regression: a 404 on the checksum URL must fail loudly and must NOT
+	// surface as "Expected: Not" (the symptom from issue #34).
+	t.Run("checksum 404 fails clearly without Expected: Not", func(t *testing.T) {
+		srv := newReleaseServer(t, releaseConfig{
+			version:     version,
+			binaryName:  binaryName,
+			binary:      fakeBinary,
+			checksum404: true,
+		})
+		defer srv.Close()
+
+		installDir := t.TempDir()
+		out, err := runInstall(t, scriptPath, srv.URL, version, installDir)
+		if err == nil {
+			t.Fatalf("install.sh should have failed on checksum 404, output:\n%s", out)
+		}
+		if strings.Contains(out, "Expected: Not") {
+			t.Errorf("regression: script parsed error body as checksum (Expected: Not)\noutput:\n%s", out)
+		}
+		if !strings.Contains(out, "Could not download checksum") {
+			t.Errorf("expected a clear checksum-download error, output:\n%s", out)
+		}
+		if _, serr := os.Stat(filepath.Join(installDir, "mockd")); serr == nil {
+			t.Errorf("binary should NOT have been installed when checksum is unavailable")
+		}
+	})
+
+	// A 404 on the binary itself must also fail loudly rather than installing the
+	// server's "Not Found" error page as an executable.
+	t.Run("binary 404 fails without installing error page", func(t *testing.T) {
+		srv := newReleaseServer(t, releaseConfig{
+			version:    version,
+			binaryName: binaryName,
+			binary404:  true,
+		})
+		defer srv.Close()
+
+		installDir := t.TempDir()
+		out, err := runInstall(t, scriptPath, srv.URL, version, installDir)
+		if err == nil {
+			t.Fatalf("install.sh should have failed on binary 404, output:\n%s", out)
+		}
+		if !strings.Contains(out, "Could not download") {
+			t.Errorf("expected a clear download error, output:\n%s", out)
+		}
+		if _, serr := os.Stat(filepath.Join(installDir, "mockd")); serr == nil {
+			t.Errorf("error page should NOT have been installed as the binary")
+		}
+	})
+
+	// A checksum file containing garbage (e.g. an unexpected HTML/error body that
+	// still returns HTTP 200) must be rejected as not-a-digest.
+	t.Run("malformed checksum body is rejected", func(t *testing.T) {
+		srv := newReleaseServer(t, releaseConfig{
+			version:      version,
+			binaryName:   binaryName,
+			binary:       fakeBinary,
+			checksumBody: "Not Found\n",
+		})
+		defer srv.Close()
+
+		installDir := t.TempDir()
+		out, err := runInstall(t, scriptPath, srv.URL, version, installDir)
+		if err == nil {
+			t.Fatalf("install.sh should have failed on malformed checksum, output:\n%s", out)
+		}
+		if strings.Contains(out, "Expected: Not") {
+			t.Errorf("regression: script parsed 'Not Found' as checksum\noutput:\n%s", out)
+		}
+		if !strings.Contains(out, "not a valid sha256 digest") {
+			t.Errorf("expected a clear malformed-checksum error, output:\n%s", out)
+		}
+	})
+}
+
+type releaseConfig struct {
+	version      string
+	binaryName   string
+	binary       []byte
+	binary404    bool
+	checksumBody string
+	checksum404  bool
+}
+
+// newReleaseServer mimics the subset of GitHub's release-download API that
+// install.sh uses: /<version>/<binaryName> and /<version>/<binaryName>.sha256.
+func newReleaseServer(t *testing.T, cfg releaseConfig) *httptest.Server {
+	t.Helper()
+	binPath := "/" + cfg.version + "/" + cfg.binaryName
+	sumPath := binPath + ".sha256"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case binPath:
+			if cfg.binary404 {
+				http.Error(w, "Not Found", http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write(cfg.binary)
+		case sumPath:
+			if cfg.checksum404 {
+				http.Error(w, "Not Found", http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(cfg.checksumBody))
+		default:
+			http.Error(w, "Not Found", http.StatusNotFound)
+		}
+	}))
+}
+
+func runInstall(t *testing.T, scriptPath, baseURL, version, installDir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"MOCKD_DOWNLOAD_BASE="+baseURL,
+		"VERSION="+version,
+		"INSTALL_DIR="+installDir,
+		"MOCKD_NO_TELEMETRY=1",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// repoFile resolves a path relative to the repository root from within the
+// tests/e2e package directory.
+func repoFile(t *testing.T, rel string) string {
+	t.Helper()
+	wd, err := os.Getwd() // .../tests/e2e
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	p := filepath.Join(root, rel)
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("could not find %s at %s: %v", rel, p, err)
+	}
+	return p
+}


### PR DESCRIPTION
## Problem

`curl -sSL https://get.mockd.io | sh` fails on macOS with:

```
error: Checksum verification failed!
  Expected: Not
  Got:      af0613532530c356b5f4469a77be10e540658f94944f4db7aa47442289e68c7c
```

`get.mockd.io` is a CloudFront redirect to this repo's `install.sh` on `raw.githubusercontent.com/getmockd/mockd/main/install.sh`, so the fix lives here.

## Root cause

`download()` used `curl -sSL` (without `--fail`) and `wget -qO`. On an HTTP 404/5xx these write the server's error body to the destination file and still exit 0. When the checksum sidecar URL 404s (e.g. a transient miss, or an asset still publishing during a re-release), GitHub returns the body `Not Found`. The script then parses the first whitespace-delimited token (`Not`) as the expected sha256 — producing the exact `Expected: Not` failure.

The same silent-failure path could install a non-binary error page as the executable when no `sha256sum`/`shasum` is available.

## Fix (`install.sh`)

- Add `--fail` to curl and clean up partial wget output, so HTTP errors return non-zero with no body left behind.
- Treat a missing or non-64-hex-char checksum as a hard, actionable error rather than a silent comparison against garbage.
- Fail clearly when the binary download itself 404s.
- Make the download/API base URLs overridable (`MOCKD_DOWNLOAD_BASE` / `MOCKD_API_BASE`) so the script can be exercised against a local server in tests. Defaults are unchanged.

## Test

`tests/e2e/install_script_test.go` drives `install.sh` against a local `httptest` server that simulates the GitHub release endpoints:

- happy path: installs and verifies checksum
- checksum 404: fails clearly, never emits `Expected: Not`, installs nothing
- binary 404: fails without installing the error page
- malformed checksum body (HTTP 200): rejected as not-a-digest

The test reproduces `Expected: Not` against the old script (fails-before) and passes against the fix (passes-after).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./tests/e2e/ -run TestInstallScript` — pass
- Ran the patched installer against the real `v0.6.6` release: downloads, verifies checksum, installs a valid ELF binary.

Fixes #34