### PR TITLE
fix(proxy): reject direct requests instead of self-looping into 502

### DIFF
--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -19,6 +19,20 @@ const (
 func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 
+	// Reject non-proxy (origin-form) requests. A proper proxy client sends the
+	// request in absolute-form (e.g. "GET http://host/path"), which populates
+	// r.URL.Host. A request sent directly to the proxy as if it were an origin
+	// server (e.g. `curl http://localhost:8888` without -x/--proxy) arrives in
+	// origin-form with an empty r.URL.Host and r.Host pointing at the proxy
+	// itself. Forwarding such a request would target the proxy's own address,
+	// creating a self-referential loop that hangs until the client timeout and
+	// returns 502 (see issue #35). Fail fast with a clear message instead.
+	if r.URL.Host == "" {
+		p.log("Rejected non-proxy request to %s%s (client must use this address as an HTTP proxy, e.g. curl -x http://<proxy> <url>)", r.Host, r.URL.Path)
+		http.Error(w, "mockd proxy received a direct request. Configure your client to use this address as an HTTP proxy (e.g. curl -x http://<proxy-host:port> <url>).", http.StatusBadRequest)
+		return
+	}
+
 	// Read and buffer the request body
 	var reqBody []byte
 	if r.Body != nil {

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -1,0 +1,72 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/getmockd/mockd/pkg/recording"
+)
+
+// TestHandleHTTPRejectsNonProxyRequest verifies that a request sent directly to
+// the proxy (origin-form, i.e. not via a proxy client) is rejected promptly with
+// a 4xx status instead of being forwarded back to the proxy's own listen address.
+//
+// Regression test for issue #35: a plain request like `curl http://localhost:8888`
+// (no -x/--proxy) arrives in origin-form with an empty r.URL.Host. The old code
+// forwarded it to r.Host (the proxy itself), creating a self-referential loop that
+// hung until the 30s client timeout and returned 502.
+func TestHandleHTTPRejectsNonProxyRequest(t *testing.T) {
+	p := New(Options{Mode: ModePassthrough})
+
+	// Origin-form request: no absolute URL, Host points at the proxy itself.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:8888"
+	req.URL.Host = "" // ensure origin-form (httptest sets this from the path already)
+
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		p.handleHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleHTTP did not return promptly for a non-proxy request (self-loop / hang)")
+	}
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d for non-proxy request, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+// TestHandleHTTPForwardsProxyRequest is a sanity check that a properly proxied
+// (absolute-form) request is still forwarded and recorded.
+func TestHandleHTTPForwardsProxyRequest(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer target.Close()
+
+	store := recording.NewStore()
+	store.CreateSession("t", nil)
+	p := New(Options{Mode: ModeRecord, Store: store})
+
+	// Absolute-form request as a proxy client would send.
+	req := httptest.NewRequest(http.MethodGet, target.URL+"/api/test", nil)
+
+	rec := httptest.NewRecorder()
+	p.handleHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from proxied request, got %d", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("unexpected body: %q", rec.Body.String())
+	}
+}


### PR DESCRIPTION
Fixes #35

## Problem

Proxy mode always returns 502 (and the dashboard surfaces an error) when a client sends a request **directly** to the proxy rather than configuring it as an HTTP proxy.

The reporter's repro:
```
curl http://localhost:8888 https://SERVICE_URL/api/v1/family
```
This `curl` invocation does **not** use `-x`/`--proxy`, so curl issues a plain origin-form `GET / HTTP/1.1` with `Host: localhost:8888` directly to mockd.

## Root cause

For a non-proxy (origin-form) request, `r.URL.Host` is empty. `forwardRequest` then builds the target as:

```go
targetURL = "http://" + r.Host + r.URL.RequestURI()   // -> http://localhost:8888/
```

i.e. it forwards the request back to the proxy's **own** listen address. That creates a self-referential loop that hangs until the 30s client timeout fires (matching the 25s / 21s / 18s durations and the `EOF` / `context deadline exceeded` spam in the issue logs), then returns 502.

## Fix

Detect origin-form (non-proxy) requests in `handleHTTP` (`r.URL.Host == ""`) and fail fast with a `400` and an actionable message instructing the user to use mockd as an HTTP proxy (`curl -x http://<proxy-host:port> <url>`). This eliminates the self-loop, the long hang, and the 502 spam. Properly proxied absolute-form requests are unaffected.

## Tests

Added `pkg/proxy/handler_test.go`:
- `TestHandleHTTPRejectsNonProxyRequest` — origin-form request returns `400` promptly (fails before the fix: returned `502`).
- `TestHandleHTTPForwardsProxyRequest` — sanity check that absolute-form proxied requests still forward and record.

Verified:
- `go build ./...`
- `go test ./pkg/proxy/...` — pass
- Existing proxy integration + binary E2E proxy tests — pass

Note: an unrelated pre-existing failure in `TestBinaryE2E_ExportMocks` reproduces on a pristine `origin/main` and is not touched by this change.