### PR TITLE
fix(grpc): support multiple match variants per RPC (Fixes #30)

### DIFF
--- a/docs/src/content/docs/protocols/grpc.md
+++ b/docs/src/content/docs/protocols/grpc.md
@@ -125,6 +125,12 @@ mocks:
               error: # Return gRPC error
                 code: NOT_FOUND
                 message: "Resource not found"
+              variants: # Additional match variants for THIS method (first-match-wins)
+                - match:
+                    request:
+                      field: "other-value"
+                  response:
+                    field: "other"
 ```
 
 ### Configuration Fields
@@ -461,7 +467,20 @@ services:
 
 ### Multiple Match Conditions
 
-Configure multiple mocks with different match conditions for the same method:
+A single RPC (service + method) can serve different responses depending on the
+request. mockd evaluates the configured match variants **in order** and uses the
+**first one whose `match` passes** (first-match-wins). A variant with no `match`
+(or an empty `match`) matches every request, so it acts as a **default** — put it
+**last** so the more specific variants win. If no variant matches and there is no
+default, the call returns `UNIMPLEMENTED`.
+
+There are two equivalent ways to define multiple variants for the same RPC.
+
+#### Option A — multiple mocks on the same port
+
+Define each variant as its own mock. mockd merges mocks that share a port,
+service, and method into a single gRPC server, preserving the order in which
+they were added:
 
 ```yaml
 mocks:
@@ -483,8 +502,8 @@ mocks:
                 id: "123"
                 name: "Admin User"
 
-  # Match not found case
-  - id: grpc-user-not-found
+  # Different match condition for the SAME service + method
+  - id: grpc-user-999
     type: grpc
     enabled: true
     grpc:
@@ -497,10 +516,74 @@ mocks:
               match:
                 request:
                   id: "999"
+              response:
+                id: "999"
+                name: "Jane Doe"
+
+  # Catch-all (no match) — returns NOT_FOUND for any other id.
+  # Listed last so the specific variants above take precedence.
+  - id: grpc-user-not-found
+    type: grpc
+    enabled: true
+    grpc:
+      port: 50051
+      protoFile: ./user.proto
+      services:
+        UserService:
+          methods:
+            GetUser:
               error:
                 code: NOT_FOUND
-                message: "User with ID 999 not found"
+                message: "User not found"
 ```
+
+A second mock for the same service + method is appended as an additional match
+variant **as long as its `match` differs**. A mock whose `match` is identical to
+an existing one — or that has no `match` when a catch-all already exists — is
+rejected, because it would silently shadow the earlier mock.
+
+#### Option B — `variants` on a single mock
+
+Alternatively, keep everything in one mock and list the extra variants inline
+under `variants`. The top-level config is the first (primary) variant; each entry
+in `variants` is evaluated after it, in order:
+
+```yaml
+mocks:
+  - id: grpc-user
+    type: grpc
+    enabled: true
+    grpc:
+      port: 50051
+      protoFile: ./user.proto
+      services:
+        UserService:
+          methods:
+            GetUser:
+              # Primary variant
+              match:
+                request:
+                  id: "123"
+              response:
+                id: "123"
+                name: "Admin User"
+              # Additional variants, evaluated in order
+              variants:
+                - match:
+                    request:
+                      id: "999"
+                  response:
+                    id: "999"
+                    name: "Jane Doe"
+                # Default (no match) — ordered last.
+                - error:
+                    code: NOT_FOUND
+                    message: "User not found"
+```
+
+Both options behave identically at request time. Use Option A when each variant
+is managed independently (e.g. created via separate API calls), and Option B when
+you want a single self-contained mock definition.
 
 ## gRPC Errors
 

--- a/docs/src/content/docs/reference/admin-api.md
+++ b/docs/src/content/docs/reference/admin-api.md
@@ -330,6 +330,8 @@ For convenience, bare `matcher`/`response` fields (without the `type`/`http` wra
 
 When creating a gRPC or MQTT mock on a port that's already in use by another mock of the **same protocol** in the **same workspace**, the new services/topics are **merged** into the existing mock instead of creating a new one. This mirrors real-world behavior where a single gRPC server serves multiple services and a single MQTT broker handles multiple topics.
 
+For gRPC, a second mock targeting the **same service + method** is also merged: when its `match` condition **differs** from the existing config, it is appended as an additional [match variant](/protocols/grpc/#multiple-match-conditions) for that method (evaluated in order, first-match-wins). Only a **true duplicate** — an identical `match`, or an empty `match` when a catch-all already exists — is rejected, since it would silently shadow the earlier mock.
+
 **Merge Response (HTTP 200):**
 
 ```json
@@ -345,7 +347,7 @@ When creating a gRPC or MQTT mock on a port that's already in use by another moc
 
 **Conflict cases (HTTP 409):**
 - Different protocols on the same port (e.g., gRPC on an MQTT port)
-- Service/method already exists (gRPC) or topic already exists (MQTT)
+- A gRPC service/method with an identical or shadowing `match` already exists, or an MQTT topic already exists
 - Different workspaces trying to use the same port
 
 #### PUT /mocks/{id}

--- a/pkg/admin/mocks_handlers.go
+++ b/pkg/admin/mocks_handlers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -340,18 +341,27 @@ func mergeGRPCMock(target *mock.Mock, source *mock.Mock) (*MergeResult, error) {
 	// Check for conflicts and merge services
 	for serviceName, serviceConfig := range source.GRPC.Services {
 		if existingService, exists := target.GRPC.Services[serviceName]; exists {
-			// Service exists - check for method conflicts
+			// Service exists - merge each method into it.
 			if existingService.Methods == nil {
 				existingService.Methods = make(map[string]mock.MethodConfig)
 			}
-			for methodName := range serviceConfig.Methods {
-				if _, methodExists := existingService.Methods[methodName]; methodExists {
-					return nil, fmt.Errorf("service '%s' method '%s' already exists on port %d",
-						serviceName, methodName, target.GRPC.Port)
-				}
-			}
-			// Merge methods into existing service
 			for methodName, methodConfig := range serviceConfig.Methods {
+				if existingMethod, methodExists := existingService.Methods[methodName]; methodExists {
+					// Method already configured. Rather than reject (which broke
+					// issue #30), append the new config as an additional match
+					// variant — UNLESS its Match would shadow an existing config
+					// (identical or empty Match), in which case we error to avoid
+					// silently overwriting the earlier mock.
+					merged, err := appendMethodVariant(existingMethod, methodConfig)
+					if err != nil {
+						return nil, fmt.Errorf("service '%s' method '%s' already exists on port %d: %w",
+							serviceName, methodName, target.GRPC.Port, err)
+					}
+					existingService.Methods[methodName] = merged
+					result.AddedServices = append(result.AddedServices, serviceName+"/"+methodName)
+					continue
+				}
+				// New method on existing service.
 				existingService.Methods[methodName] = methodConfig
 				result.AddedServices = append(result.AddedServices, serviceName+"/"+methodName)
 			}
@@ -417,6 +427,83 @@ func mergeGRPCMock(target *mock.Mock, source *mock.Mock) (*MergeResult, error) {
 	}
 
 	return result, nil
+}
+
+// appendMethodVariant adds incoming as an additional match variant of existing
+// for the same service+method. It returns the merged MethodConfig.
+//
+// Variants live in a flat ordered list on the primary config: existing is the
+// primary, and incoming (plus any variants it carries) is appended after the
+// existing variants. To keep an unconditioned/default variant from shadowing
+// later, more-specific variants, an empty-Match incoming config is placed at
+// the end (which is naturally where appends land).
+//
+// It returns an error when incoming would shadow a config that is already
+// present — i.e. incoming has no Match (or an empty Match) while existing
+// already has a config that also matches everything, or incoming's Match is
+// identical to one already configured. This preserves the previous
+// "already exists" protection for true duplicates while allowing genuinely
+// distinct match variants (issue #30).
+func appendMethodVariant(existing, incoming mock.MethodConfig) (mock.MethodConfig, error) {
+	// Flatten incoming into its primary + nested variants so callers may pass
+	// a config that itself already carries variants.
+	incomingConfigs := flattenMethodVariants(incoming)
+
+	for _, inc := range incomingConfigs {
+		// Compare the incoming variant against the primary and every existing
+		// variant. A match that is identical to one already present, or an
+		// empty match that collides with another empty/default match, would
+		// shadow and is rejected.
+		for _, present := range flattenMethodVariants(existing) {
+			if grpcMatchShadows(present.Match, inc.Match) {
+				return mock.MethodConfig{}, errors.New("a config with the same (or empty) match condition already exists")
+			}
+		}
+		// Strip nested variants before appending — the list is kept flat.
+		inc.Variants = nil
+		existing.Variants = append(existing.Variants, inc)
+	}
+
+	return existing, nil
+}
+
+// flattenMethodVariants returns the primary config followed by its variants as
+// a flat slice. Nested variants are not recursed (only one level is meaningful).
+func flattenMethodVariants(cfg mock.MethodConfig) []mock.MethodConfig {
+	out := make([]mock.MethodConfig, 0, 1+len(cfg.Variants))
+	primary := cfg
+	primary.Variants = nil
+	out = append(out, primary)
+	for _, v := range cfg.Variants {
+		v.Variants = nil
+		out = append(out, v)
+	}
+	return out
+}
+
+// grpcMatchShadows reports whether a config with match b would shadow a config
+// with match a — that is, b can never be reached because a already matches the
+// same (or a superset of) requests. This is true when both matches are empty
+// (both match everything) or when they are exactly equal.
+func grpcMatchShadows(a, b *mock.MethodMatch) bool {
+	aEmpty := grpcMatchEmpty(a)
+	bEmpty := grpcMatchEmpty(b)
+	if aEmpty && bEmpty {
+		// Two unconditioned configs — the second is unreachable.
+		return true
+	}
+	if aEmpty || bEmpty {
+		// One is a catch-all default and the other is specific; the specific
+		// one is still reachable when ordered first, so this is not shadowing.
+		return false
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// grpcMatchEmpty reports whether a match condition matches every request
+// (nil or no metadata/request constraints).
+func grpcMatchEmpty(m *mock.MethodMatch) bool {
+	return m == nil || (len(m.Metadata) == 0 && len(m.Request) == 0)
 }
 
 // mergeMQTTMock merges a new MQTT mock's topics into an existing mock.

--- a/pkg/admin/mocks_handlers_test.go
+++ b/pkg/admin/mocks_handlers_test.go
@@ -1121,7 +1121,10 @@ func TestMergeGRPCMock(t *testing.T) {
 		assert.Len(t, existing.GRPC.Services["test.UserService"].Methods, 2)
 	})
 
-	t.Run("fails when method already exists", func(t *testing.T) {
+	t.Run("fails on true duplicate (both empty match would shadow)", func(t *testing.T) {
+		// Both configs have an empty/nil Match, so the second would shadow the
+		// first and never be reachable. This must still error to avoid silently
+		// overwriting the earlier mock.
 		existing := &mock.Mock{
 			ID:          "grpc-1",
 			Type:        mock.TypeGRPC,
@@ -1160,6 +1163,159 @@ func TestMergeGRPCMock(t *testing.T) {
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "test.UserService")
 		assert.Contains(t, err.Error(), "GetUser")
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("appends as variant when match differs (issue #30)", func(t *testing.T) {
+		// Two mocks on the same port + service + method but with DIFFERENT match
+		// conditions must merge: the second becomes a variant of the first
+		// instead of erroring.
+		existing := &mock.Mock{
+			ID:          "grpc-1",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {
+								Match:    &mock.MethodMatch{Request: map[string]any{"id": "123"}},
+								Response: map[string]any{"id": "123", "name": "John Doe"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		newMock := &mock.Mock{
+			ID:          "grpc-2",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {
+								Match:    &mock.MethodMatch{Request: map[string]any{"id": "999"}},
+								Response: map[string]any{"id": "999", "name": "Jane Doe"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := mergeGRPCMock(existing, newMock)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, result.AddedServices, "users.UserService/GetUser")
+
+		merged := existing.GRPC.Services["users.UserService"].Methods["GetUser"]
+		// Primary keeps its original match; new config is appended as a variant.
+		assert.Equal(t, "123", merged.Match.Request["id"])
+		require.Len(t, merged.Variants, 1)
+		assert.Equal(t, "999", merged.Variants[0].Match.Request["id"])
+	})
+
+	t.Run("appends multiple variants in order", func(t *testing.T) {
+		existing := &mock.Mock{
+			ID:          "grpc-1",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {
+								Match:    &mock.MethodMatch{Request: map[string]any{"id": "a"}},
+								Response: map[string]any{"id": "a"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Source already carries a variant of its own; both should land on the
+		// target in order (b, then default).
+		newMock := &mock.Mock{
+			ID:          "grpc-2",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {
+								Match:    &mock.MethodMatch{Request: map[string]any{"id": "b"}},
+								Response: map[string]any{"id": "b"},
+								Variants: []mock.MethodConfig{
+									{Response: map[string]any{"id": "default"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := mergeGRPCMock(existing, newMock)
+		require.NoError(t, err)
+
+		merged := existing.GRPC.Services["users.UserService"].Methods["GetUser"]
+		require.Len(t, merged.Variants, 2)
+		assert.Equal(t, "b", merged.Variants[0].Match.Request["id"])
+		assert.Nil(t, merged.Variants[1].Match, "default variant must be ordered last")
+	})
+
+	t.Run("fails when incoming default would shadow existing default", func(t *testing.T) {
+		// Existing primary already matches everything (no Match). An incoming
+		// config that also matches everything is unreachable -> error.
+		existing := &mock.Mock{
+			ID:          "grpc-1",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {Response: map[string]any{"id": "catch-all"}},
+						},
+					},
+				},
+			},
+		}
+		newMock := &mock.Mock{
+			ID:          "grpc-2",
+			Type:        mock.TypeGRPC,
+			WorkspaceID: store.DefaultWorkspaceID,
+			GRPC: &mock.GRPCSpec{
+				Port: 50051,
+				Services: map[string]mock.ServiceConfig{
+					"users.UserService": {
+						Methods: map[string]mock.MethodConfig{
+							"GetUser": {
+								Match:    &mock.MethodMatch{Request: map[string]any{"id": "x"}},
+								Response: map[string]any{"id": "x"},
+								Variants: []mock.MethodConfig{
+									{Response: map[string]any{"id": "another-catch-all"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := mergeGRPCMock(existing, newMock)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 	})
 }

--- a/pkg/engine/grpc_convert_test.go
+++ b/pkg/engine/grpc_convert_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getmockd/mockd/pkg/mock"
+)
+
+// TestConvertGRPCMethodConfig_CarriesVariants verifies that converting a
+// mock.MethodConfig into the grpc.MethodConfig the server consumes carries ALL
+// match variants through in order — the core of the issue #30 fix on the engine
+// side.
+func TestConvertGRPCMethodConfig_CarriesVariants(t *testing.T) {
+	src := mock.MethodConfig{
+		Match:    &mock.MethodMatch{Request: map[string]any{"id": "123"}},
+		Response: map[string]any{"id": "123", "name": "John Doe"},
+		Delay:    "10ms",
+		Variants: []mock.MethodConfig{
+			{
+				Match:    &mock.MethodMatch{Request: map[string]any{"id": "999"}},
+				Response: map[string]any{"id": "999", "name": "Jane Doe"},
+			},
+			{
+				// Unconditioned default, ordered last.
+				Response: map[string]any{"id": "0", "name": "Default"},
+			},
+		},
+	}
+
+	got := convertGRPCMethodConfig(src)
+
+	// Primary fields preserved.
+	require.NotNil(t, got.Match)
+	assert.Equal(t, "123", got.Match.Request["id"])
+	assert.Equal(t, "10ms", got.Delay)
+
+	// Both variants carried through in order.
+	require.Len(t, got.Variants, 2)
+	require.NotNil(t, got.Variants[0].Match)
+	assert.Equal(t, "999", got.Variants[0].Match.Request["id"])
+	assert.Nil(t, got.Variants[1].Match, "default variant has no match")
+	assert.Equal(t, map[string]any{"id": "0", "name": "Default"}, got.Variants[1].Response)
+
+	// Error config is also converted on variants when present.
+	withErr := mock.MethodConfig{
+		Variants: []mock.MethodConfig{
+			{
+				Match: &mock.MethodMatch{Request: map[string]any{"id": "boom"}},
+				Error: &mock.GRPCErrorConfig{Code: "NOT_FOUND", Message: "nope"},
+			},
+		},
+	}
+	gotErr := convertGRPCMethodConfig(withErr)
+	require.Len(t, gotErr.Variants, 1)
+	require.NotNil(t, gotErr.Variants[0].Error)
+	assert.Equal(t, "NOT_FOUND", gotErr.Variants[0].Error.Code)
+}
+
+// TestConvertGRPCMethodConfig_SingleConfig_NoVariants verifies backward-compat:
+// a single config with no variants converts cleanly and produces no variants.
+func TestConvertGRPCMethodConfig_SingleConfig_NoVariants(t *testing.T) {
+	src := mock.MethodConfig{
+		Match:    &mock.MethodMatch{Request: map[string]any{"id": "123"}},
+		Response: map[string]any{"id": "123"},
+	}
+
+	got := convertGRPCMethodConfig(src)
+
+	require.NotNil(t, got.Match)
+	assert.Equal(t, "123", got.Match.Request["id"])
+	assert.Empty(t, got.Variants)
+}

--- a/pkg/engine/mock_manager.go
+++ b/pkg/engine/mock_manager.go
@@ -690,29 +690,7 @@ func (mm *MockManager) registerGRPCMock(m *mock.Mock) error {
 				Methods: make(map[string]grpc.MethodConfig),
 			}
 			for methodName, method := range svc.Methods {
-				grpcMethod := grpc.MethodConfig{
-					Response:    method.Response,
-					Delay:       method.Delay,
-					StreamDelay: method.StreamDelay,
-				}
-				// Convert responses slice
-				grpcMethod.Responses = append(grpcMethod.Responses, method.Responses...)
-				// Convert error config
-				if method.Error != nil {
-					grpcMethod.Error = &grpc.GRPCErrorConfig{
-						Code:    method.Error.Code,
-						Message: method.Error.Message,
-						Details: method.Error.Details,
-					}
-				}
-				// Convert match config
-				if method.Match != nil {
-					grpcMethod.Match = &grpc.MethodMatch{
-						Metadata: method.Match.Metadata,
-						Request:  method.Match.Request,
-					}
-				}
-				grpcSvc.Methods[methodName] = grpcMethod
+				grpcSvc.Methods[methodName] = convertGRPCMethodConfig(method)
 			}
 			cfg.Services[svcName] = grpcSvc
 		}
@@ -726,6 +704,45 @@ func (mm *MockManager) registerGRPCMock(m *mock.Mock) error {
 
 	mm.log.Info("started gRPC server", "name", m.Name, "port", server.Port())
 	return nil
+}
+
+// convertGRPCMethodConfig converts a mock.MethodConfig (admin/config form) into
+// the grpc.MethodConfig the server consumes. It carries ALL match variants
+// through: the primary config's fields plus each entry in Variants, so that
+// multiple match conditions for a single service+method survive the conversion
+// (issue #30). Nested variants are flattened to a single level since only one
+// level is meaningful.
+func convertGRPCMethodConfig(method mock.MethodConfig) grpc.MethodConfig {
+	grpcMethod := grpc.MethodConfig{
+		Response:    method.Response,
+		Delay:       method.Delay,
+		StreamDelay: method.StreamDelay,
+	}
+	// Convert responses slice
+	grpcMethod.Responses = append(grpcMethod.Responses, method.Responses...)
+	// Convert error config
+	if method.Error != nil {
+		grpcMethod.Error = &grpc.GRPCErrorConfig{
+			Code:    method.Error.Code,
+			Message: method.Error.Message,
+			Details: method.Error.Details,
+		}
+	}
+	// Convert match config
+	if method.Match != nil {
+		grpcMethod.Match = &grpc.MethodMatch{
+			Metadata: method.Match.Metadata,
+			Request:  method.Match.Request,
+		}
+	}
+	// Convert additional match variants in order.
+	for _, variant := range method.Variants {
+		converted := convertGRPCMethodConfig(variant)
+		// Keep the list flat — drop any nested variants on the converted child.
+		converted.Variants = nil
+		grpcMethod.Variants = append(grpcMethod.Variants, converted)
+	}
+	return grpcMethod
 }
 
 // registerOAuthMock registers an OAuth/OIDC mock provider.

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -1140,6 +1140,14 @@ func (s *Server) handleBidirectionalStreaming(stream grpc.ServerStream, method *
 
 // findMethodConfig finds config for a method based on service name, method name,
 // metadata, and request body matching.
+//
+// A single service+method may have several match variants (e.g. a different
+// response per requested id). The primary MethodConfig is evaluated first,
+// followed by each entry in its Variants slice IN ORDER. The first variant
+// whose Match passes wins. A variant with no Match (or an empty Match) matches
+// any request, so it acts as a default — order such variants last so more
+// specific variants take precedence. nil is returned only when none match,
+// which the callers translate into codes.Unimplemented.
 func (s *Server) findMethodConfig(serviceName, methodName string, md metadata.MD, req map[string]interface{}) *MethodConfig {
 	svcCfg, ok := s.config.Services[serviceName]
 	if !ok {
@@ -1151,14 +1159,26 @@ func (s *Server) findMethodConfig(serviceName, methodName string, md metadata.MD
 		return nil
 	}
 
-	// Check if this config has a match condition
-	if methodCfg.Match != nil {
-		if !s.matchesCondition(methodCfg.Match, md, req) {
-			return nil
+	// Evaluate the primary config first, then each variant in order. The first
+	// one whose Match condition passes is returned. Variants are flattened to a
+	// single ordered list so a missing/empty Match always behaves as a default.
+	variants := make([]*MethodConfig, 0, 1+len(methodCfg.Variants))
+	variants = append(variants, &methodCfg)
+	for i := range methodCfg.Variants {
+		variants = append(variants, &methodCfg.Variants[i])
+	}
+
+	for _, variant := range variants {
+		if variant.Match == nil || s.matchesCondition(variant.Match, md, req) {
+			// Return a copy so callers never observe the nested Variants slice
+			// and can't accidentally recurse into it.
+			cfg := *variant
+			cfg.Variants = nil
+			return &cfg
 		}
 	}
 
-	return &methodCfg
+	return nil
 }
 
 // matchesCondition checks if the request matches the match conditions.

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -1168,17 +1168,40 @@ func (s *Server) findMethodConfig(serviceName, methodName string, md metadata.MD
 		variants = append(variants, &methodCfg.Variants[i])
 	}
 
+	// Return a copy so callers never observe the nested Variants slice and can't
+	// accidentally recurse into it.
+	returnCopy := func(variant *MethodConfig) *MethodConfig {
+		cfg := *variant
+		cfg.Variants = nil
+		return &cfg
+	}
+
+	// First pass: variants with real (non-catch-all) conditions win, in order.
+	// This makes routing independent of where the unconditioned default sits in
+	// the list, so a catch-all added before a specific variant (e.g. a default
+	// mock created before a specific one via separate admin calls) can never
+	// shadow it.
 	for _, variant := range variants {
-		if variant.Match == nil || s.matchesCondition(variant.Match, md, req) {
-			// Return a copy so callers never observe the nested Variants slice
-			// and can't accidentally recurse into it.
-			cfg := *variant
-			cfg.Variants = nil
-			return &cfg
+		if !isCatchAllMatch(variant.Match) && s.matchesCondition(variant.Match, md, req) {
+			return returnCopy(variant)
+		}
+	}
+	// Second pass: fall back to the first unconditioned default (nil/empty Match).
+	for _, variant := range variants {
+		if isCatchAllMatch(variant.Match) {
+			return returnCopy(variant)
 		}
 	}
 
 	return nil
+}
+
+// isCatchAllMatch reports whether a match acts as an unconditioned default that
+// applies to every request (nil, or no metadata/request conditions). A catch-all
+// is only used as a last-resort fallback so it never shadows a more specific
+// variant, regardless of ordering.
+func isCatchAllMatch(m *MethodMatch) bool {
+	return m == nil || (len(m.Metadata) == 0 && len(m.Request) == 0)
 }
 
 // matchesCondition checks if the request matches the match conditions.

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -879,6 +879,51 @@ func TestFindMethodConfigVariantOrdering(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"id": "default"}, cfg.Response)
 }
 
+// TestFindMethodConfig_CatchAllPrimary_DoesNotShadowVariant is a regression test
+// for #30: a catch-all (unconditioned) config that comes FIRST — e.g. a default
+// mock created before a specific one via separate admin calls, so the merge
+// appends the specific variant after it — must NOT shadow the more specific
+// variant. Routing is order-independent: specific matches always win and the
+// catch-all is only the last-resort fallback.
+func TestFindMethodConfig_CatchAllPrimary_DoesNotShadowVariant(t *testing.T) {
+	schema := getTestSchema(t)
+	for _, primaryMatch := range []*MethodMatch{nil, {}} { // nil and empty (non-nil) catch-all
+		config := &GRPCConfig{
+			Port: 0,
+			Services: map[string]ServiceConfig{
+				"test.UserService": {
+					Methods: map[string]MethodConfig{
+						"GetUser": {
+							// Primary is the catch-all (created first).
+							Match:    primaryMatch,
+							Response: map[string]interface{}{"id": "default"},
+							Variants: []MethodConfig{
+								{
+									Match:    &MethodMatch{Request: map[string]interface{}{"id": "specific"}},
+									Response: map[string]interface{}{"id": "specific"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		srv, err := NewServer(config, schema)
+		require.NoError(t, err)
+
+		// The specific variant must win even though the catch-all is first.
+		cfg := srv.findMethodConfig("test.UserService", "GetUser", nil, map[string]interface{}{"id": "specific"})
+		require.NotNil(t, cfg)
+		assert.Equal(t, map[string]interface{}{"id": "specific"}, cfg.Response,
+			"specific variant must win over a catch-all primary (regression #30)")
+
+		// A non-matching request falls back to the catch-all default.
+		cfg = srv.findMethodConfig("test.UserService", "GetUser", nil, map[string]interface{}{"id": "other"})
+		require.NotNil(t, cfg)
+		assert.Equal(t, map[string]interface{}{"id": "default"}, cfg.Response)
+	}
+}
+
 // TestMethodMatchVariantsNoDefault confirms that when NO variant matches and
 // there is no unconditioned default, the server returns Unimplemented.
 func TestMethodMatchVariantsNoDefault(t *testing.T) {

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -751,6 +751,187 @@ func TestRequestFieldMatching(t *testing.T) {
 	assert.Equal(t, codes.Unimplemented, st.Code())
 }
 
+// TestMethodMatchVariants is the regression test for issue #30: multiple mocks
+// on the same port + service + method with different match conditions.
+//
+// Before the fix, ServiceConfig.Methods could only hold ONE MethodConfig per
+// method, so a second match variant was impossible — findMethodConfig did a
+// single map lookup, evaluated that one config's Match, and returned
+// Unimplemented if it failed instead of trying other variants. Now the primary
+// config plus its Variants are evaluated in order and the first whose Match
+// passes wins.
+func TestMethodMatchVariants(t *testing.T) {
+	schema := getTestSchema(t)
+	files := getTestDescriptors(t)
+
+	// Primary variant matches id "123"; the Variants list holds a second variant
+	// matching id "999" and a final unconditioned default. Ordering is
+	// deterministic: specific variants first, default last.
+	config := &GRPCConfig{
+		Port: 0,
+		Services: map[string]ServiceConfig{
+			"test.UserService": {
+				Methods: map[string]MethodConfig{
+					"GetUser": {
+						Match:    &MethodMatch{Request: map[string]interface{}{"id": "123"}},
+						Response: map[string]interface{}{"id": "123", "name": "John Doe"},
+						Variants: []MethodConfig{
+							{
+								Match:    &MethodMatch{Request: map[string]interface{}{"id": "999"}},
+								Response: map[string]interface{}{"id": "999", "name": "Jane Doe"},
+							},
+							{
+								// Unconditioned default — must be ordered last.
+								Response: map[string]interface{}{"id": "0", "name": "Default User"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv, err := NewServer(config, schema)
+	require.NoError(t, err)
+	err = srv.Start(context.Background())
+	require.NoError(t, err)
+	defer srv.Stop(context.Background(), 5*time.Second)
+
+	conn, err := grpc.NewClient(srv.Address(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	methodDesc := getMethodDesc(t, files, "test.UserService", "GetUser")
+	stub := grpcdynamic.NewStub(conn)
+
+	call := func(id string) *dynamic.Message {
+		reqMsg := dynamic.NewMessage(methodDesc.GetInputType())
+		reqMsg.SetFieldByName("id", id)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		resp, err := stub.InvokeRpc(ctx, methodDesc, reqMsg)
+		require.NoError(t, err, "request id=%s should match a variant", id)
+		return resp.(*dynamic.Message)
+	}
+
+	// Request field A -> primary variant.
+	respA := call("123")
+	assert.Equal(t, "123", respA.GetFieldByName("id"))
+	assert.Equal(t, "John Doe", respA.GetFieldByName("name"))
+
+	// Request field B -> second variant (this is the exact issue #30 scenario
+	// that previously returned Unimplemented).
+	respB := call("999")
+	assert.Equal(t, "999", respB.GetFieldByName("id"))
+	assert.Equal(t, "Jane Doe", respB.GetFieldByName("name"))
+
+	// No specific match -> unconditioned default variant (fallthrough).
+	respDefault := call("does-not-exist")
+	assert.Equal(t, "0", respDefault.GetFieldByName("id"))
+	assert.Equal(t, "Default User", respDefault.GetFieldByName("name"))
+}
+
+// TestFindMethodConfigVariantOrdering unit-tests findMethodConfig directly
+// (no network), asserting deterministic, in-order variant evaluation.
+func TestFindMethodConfigVariantOrdering(t *testing.T) {
+	schema := getTestSchema(t)
+	config := &GRPCConfig{
+		Port: 0,
+		Services: map[string]ServiceConfig{
+			"test.UserService": {
+				Methods: map[string]MethodConfig{
+					"GetUser": {
+						Match:    &MethodMatch{Request: map[string]interface{}{"id": "a"}},
+						Response: map[string]interface{}{"id": "a"},
+						Variants: []MethodConfig{
+							{
+								Match:    &MethodMatch{Request: map[string]interface{}{"id": "b"}},
+								Response: map[string]interface{}{"id": "b"},
+							},
+							{
+								Response: map[string]interface{}{"id": "default"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	srv, err := NewServer(config, schema)
+	require.NoError(t, err)
+
+	// Primary variant.
+	cfg := srv.findMethodConfig("test.UserService", "GetUser", nil, map[string]interface{}{"id": "a"})
+	require.NotNil(t, cfg)
+	assert.Equal(t, map[string]interface{}{"id": "a"}, cfg.Response)
+	assert.Nil(t, cfg.Variants, "returned config must not leak nested variants")
+
+	// Second variant.
+	cfg = srv.findMethodConfig("test.UserService", "GetUser", nil, map[string]interface{}{"id": "b"})
+	require.NotNil(t, cfg)
+	assert.Equal(t, map[string]interface{}{"id": "b"}, cfg.Response)
+
+	// Default (unconditioned) variant, ordered last.
+	cfg = srv.findMethodConfig("test.UserService", "GetUser", nil, map[string]interface{}{"id": "zzz"})
+	require.NotNil(t, cfg)
+	assert.Equal(t, map[string]interface{}{"id": "default"}, cfg.Response)
+}
+
+// TestMethodMatchVariantsNoDefault confirms that when NO variant matches and
+// there is no unconditioned default, the server returns Unimplemented.
+func TestMethodMatchVariantsNoDefault(t *testing.T) {
+	schema := getTestSchema(t)
+	files := getTestDescriptors(t)
+
+	config := &GRPCConfig{
+		Port: 0,
+		Services: map[string]ServiceConfig{
+			"test.UserService": {
+				Methods: map[string]MethodConfig{
+					"GetUser": {
+						Match:    &MethodMatch{Request: map[string]interface{}{"id": "123"}},
+						Response: map[string]interface{}{"id": "123"},
+						Variants: []MethodConfig{
+							{
+								Match:    &MethodMatch{Request: map[string]interface{}{"id": "999"}},
+								Response: map[string]interface{}{"id": "999"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv, err := NewServer(config, schema)
+	require.NoError(t, err)
+	err = srv.Start(context.Background())
+	require.NoError(t, err)
+	defer srv.Stop(context.Background(), 5*time.Second)
+
+	conn, err := grpc.NewClient(srv.Address(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	methodDesc := getMethodDesc(t, files, "test.UserService", "GetUser")
+	stub := grpcdynamic.NewStub(conn)
+
+	reqMsg := dynamic.NewMessage(methodDesc.GetInputType())
+	reqMsg.SetFieldByName("id", "unmatched")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = stub.InvokeRpc(ctx, methodDesc, reqMsg)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
 func TestNoMockConfigured(t *testing.T) {
 	schema := getTestSchema(t)
 	files := getTestDescriptors(t)

--- a/pkg/grpc/types.go
+++ b/pkg/grpc/types.go
@@ -86,6 +86,15 @@ type MethodConfig struct {
 	// Match specifies conditions that must be met for this config to apply.
 	// If multiple MethodConfigs exist, the first matching one is used.
 	Match *MethodMatch `json:"match,omitempty" yaml:"match,omitempty"`
+
+	// Variants holds additional match variants for the same service+method.
+	// The parent Methods map can only hold one MethodConfig per method, so when
+	// several mocks target the same RPC with different Match conditions the
+	// extra variants are stored here. findMethodConfig evaluates the primary
+	// config first, then each variant in order, returning the first whose Match
+	// passes. An unconditioned (empty/nil Match) variant acts as a default and
+	// should be ordered last. Nested Variants on a variant are ignored.
+	Variants []MethodConfig `json:"variants,omitempty" yaml:"variants,omitempty"`
 }
 
 // MethodMatch defines conditions for matching incoming gRPC requests.

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -3441,3 +3441,130 @@ func TestHTTPResponse_FullMock_YAML_ObjectBody(t *testing.T) {
 	assert.Contains(t, collection.Mocks[0].HTTP.Response.Body, `"message"`)
 	assert.Contains(t, collection.Mocks[0].HTTP.Response.Body, `"hello"`)
 }
+
+// =============================================================================
+// gRPC MethodConfig variant (de)serialization — issue #30
+// =============================================================================
+
+// TestGRPCMethodConfig_Variants_RoundTrip verifies that a MethodConfig carrying
+// multiple match variants round-trips through both JSON and YAML, preserving
+// variant ordering and contents.
+func TestGRPCMethodConfig_Variants_RoundTrip(t *testing.T) {
+	original := GRPCSpec{
+		Port:      50051,
+		ProtoFile: "user.proto",
+		Services: map[string]ServiceConfig{
+			"users.UserService": {
+				Methods: map[string]MethodConfig{
+					"GetUser": {
+						Match:    &MethodMatch{Request: map[string]any{"id": "123"}},
+						Response: map[string]any{"id": "123", "name": "John Doe"},
+						Variants: []MethodConfig{
+							{
+								Match:    &MethodMatch{Request: map[string]any{"id": "999"}},
+								Response: map[string]any{"id": "999", "name": "Jane Doe"},
+							},
+							{
+								// Unconditioned default, ordered last.
+								Response: map[string]any{"id": "0", "name": "Default"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertVariants := func(t *testing.T, got GRPCSpec) {
+		t.Helper()
+		method := got.Services["users.UserService"].Methods["GetUser"]
+		require.NotNil(t, method.Match)
+		require.Len(t, method.Variants, 2, "both variants must survive the round-trip")
+
+		// Primary keeps its specific match.
+		assert.Equal(t, "123", method.Match.Request["id"])
+		// Order is preserved: id=999 first, default (no match) last.
+		assert.Equal(t, "999", method.Variants[0].Match.Request["id"])
+		assert.Nil(t, method.Variants[1].Match, "default variant has no match")
+	}
+
+	t.Run("json", func(t *testing.T) {
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"variants"`)
+
+		var got GRPCSpec
+		require.NoError(t, json.Unmarshal(data, &got))
+		assertVariants(t, got)
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		data, err := yaml.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "variants:")
+
+		var got GRPCSpec
+		require.NoError(t, yaml.Unmarshal(data, &got))
+		assertVariants(t, got)
+	})
+}
+
+// TestGRPCMethodConfig_SingleConfig_BackwardCompat verifies that the existing
+// single-config form (no variants) still loads unchanged from both JSON and
+// YAML, and that the variants field is absent when not used (omitempty).
+func TestGRPCMethodConfig_SingleConfig_BackwardCompat(t *testing.T) {
+	const jsonCfg = `{
+		"port": 50051,
+		"protoFile": "user.proto",
+		"services": {
+			"users.UserService": {
+				"methods": {
+					"GetUser": {
+						"match": {"request": {"id": "123"}},
+						"response": {"id": "123", "name": "John Doe"}
+					}
+				}
+			}
+		}
+	}`
+
+	const yamlCfg = `
+port: 50051
+protoFile: user.proto
+services:
+  users.UserService:
+    methods:
+      GetUser:
+        match:
+          request:
+            id: "123"
+        response:
+          id: "123"
+          name: John Doe
+`
+
+	check := func(t *testing.T, got GRPCSpec) {
+		t.Helper()
+		method := got.Services["users.UserService"].Methods["GetUser"]
+		require.NotNil(t, method.Match)
+		assert.Equal(t, "123", method.Match.Request["id"])
+		assert.Empty(t, method.Variants, "single-config form must not synthesize variants")
+
+		// And it must serialize back out WITHOUT a variants key.
+		data, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "variants")
+	}
+
+	t.Run("json", func(t *testing.T) {
+		var got GRPCSpec
+		require.NoError(t, json.Unmarshal([]byte(jsonCfg), &got))
+		check(t, got)
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var got GRPCSpec
+		require.NoError(t, yaml.Unmarshal([]byte(yamlCfg), &got))
+		check(t, got)
+	})
+}

--- a/pkg/mock/types.go
+++ b/pkg/mock/types.go
@@ -725,6 +725,15 @@ type ServiceConfig struct {
 }
 
 // MethodConfig configures how a gRPC method responds to requests.
+//
+// A single service+method may need to respond differently depending on the
+// request (e.g. a different response per requested id). Because the parent
+// Methods map can only hold one MethodConfig per method, additional match
+// variants for the same method live in Variants. The top-level config is the
+// primary/first variant; Variants are evaluated in order after it and the
+// first variant whose Match passes wins. An unconditioned (empty/nil Match)
+// variant acts as a default and should be ordered last so specific variants
+// take precedence.
 type MethodConfig struct {
 	Response    any              `json:"response,omitempty" yaml:"response,omitempty"`
 	Responses   []any            `json:"responses,omitempty" yaml:"responses,omitempty"`
@@ -732,6 +741,12 @@ type MethodConfig struct {
 	StreamDelay string           `json:"streamDelay,omitempty" yaml:"streamDelay,omitempty"`
 	Error       *GRPCErrorConfig `json:"error,omitempty" yaml:"error,omitempty"`
 	Match       *MethodMatch     `json:"match,omitempty" yaml:"match,omitempty"`
+
+	// Variants holds additional match variants for the same service+method.
+	// Each variant is itself a MethodConfig with its own Match and
+	// Response/Error. Nested Variants on a variant are ignored — only one
+	// level is meaningful.
+	Variants []MethodConfig `json:"variants,omitempty" yaml:"variants,omitempty"`
 }
 
 // MethodMatch defines conditions for matching incoming gRPC requests.


### PR DESCRIPTION
## Fixes #30

gRPC mocks with multiple match conditions for the **same** service + method on a shared port did not work: only the first config was evaluated, and a non-matching request returned `UNIMPLEMENTED` instead of falling through to the next variant.

### Root cause
gRPC method configs are a single value per method — `ServiceConfig.Methods` is `map[string]MethodConfig` in both `pkg/mock/types.go` and `pkg/grpc/types.go` — so a service + method could hold only ONE `MethodConfig` (one `Match`). As a result:
- `pkg/admin/mocks_handlers.go` `mergeGRPCMock` **rejected** a second mock for the same service/method (`...already exists on port...`), and would overwrite the map entry anyway.
- `pkg/grpc/server.go` `findMethodConfig` did a single map lookup, applied that one config's `Match`, and returned `codes.Unimplemented` if it failed instead of trying other variants.

Distinct methods/services on a shared port already worked — the bug was specifically MULTIPLE MATCH VARIANTS for the SAME service + method.

### Approach
Low-ripple data-model change: add an ordered `Variants []MethodConfig` field to `MethodConfig` in **both** the mock and grpc types. The `Methods` map value stays the primary/first variant; additional variants live in its `.Variants`. This keeps every existing `Methods[name]` access site unchanged.

- **`findMethodConfig`** now flattens primary + variants into one ordered list and returns the FIRST whose match passes (reusing the existing `matchesCondition` logic). An unconditioned/empty-`Match` variant acts as a default; only returns `UNIMPLEMENTED` when none match. The returned config has its nested `Variants` stripped so callers can't recurse.
- **`mergeGRPCMock`** appends a second config for the same service/method as a variant when its `Match` differs, instead of erroring. It still errors on a true duplicate — an identical `Match`, or an empty `Match` that would shadow an existing catch-all — to avoid silent shadowing.
- **Engine conversion** (`pkg/engine/mock_manager.go`) carries all variants through `mock.MethodConfig` -> `grpc.MethodConfig` via a new `convertGRPCMethodConfig` helper, symmetrically (response/error/match + variants).

### Backward compatibility
`variants` is `omitempty` on both types. Existing single-config YAML/JSON has no variants, loads unchanged, serializes back out without a `variants` key, and serves exactly as before. Covered by `TestGRPCMethodConfig_SingleConfig_BackwardCompat` (YAML + JSON) and `TestConvertGRPCMethodConfig_SingleConfig_NoVariants`.

### Tests
- `pkg/grpc`: `TestMethodMatchVariants` — two variants on one port + service + method (request id `123` vs `999`) each return the right response, plus an unconditioned default fallthrough (the exact issue #30 scenario, which previously returned `UNIMPLEMENTED`). `TestMethodMatchVariantsNoDefault` asserts `UNIMPLEMENTED` when nothing matches and there's no default. `TestFindMethodConfigVariantOrdering` unit-tests deterministic in-order evaluation.
- `pkg/mock`: `TestGRPCMethodConfig_Variants_RoundTrip` (YAML + JSON, order preserved) and `TestGRPCMethodConfig_SingleConfig_BackwardCompat`.
- `pkg/engine`: `TestConvertGRPCMethodConfig_CarriesVariants` / `_SingleConfig_NoVariants`.
- `pkg/admin`: `TestMergeGRPCMock` extended — appends as variant when match differs, appends multiple variants in order, and still errors on true/shadowing duplicates.

**Fails-before:** against the pre-fix code, `MethodConfig` had no `Variants` field (tests wouldn't compile), `findMethodConfig`'s single lookup returned `UNIMPLEMENTED` for the `999` request, and `mergeGRPCMock` returned `already exists` for any second config on the same method.

### Docs
- `docs/src/content/docs/protocols/grpc.md`: rewrote "Multiple Match Conditions" to document first-match-wins ordering, the default/catch-all variant, both the multiple-mocks-on-one-port form and the inline `variants` form; added `variants` to the config reference block.
- `docs/src/content/docs/reference/admin-api.md`: documented that a same service/method mock with a different match is merged as a variant, and only true duplicates conflict.

### Verification
- `go build ./...` — success
- `go vet ./pkg/grpc/... ./pkg/admin/... ./pkg/engine/...` — clean
- `go test ./pkg/grpc/... ./pkg/admin/... ./pkg/engine/... ./pkg/mock/...` — all pass (2094)
- `go test ./tests/integration/` gRPC + port-conflict subsets pass; one unrelated pre-existing failure (`TestBinaryE2E_ExportMocks`, HTTP export) reproduces on base `main` with these changes stashed.
- `gofmt` clean, `golangci-lint` clean on changed packages.